### PR TITLE
ROSAENG-906: Request AWS additional SQS permissions for ROSA Managed Policies (Spot Instance Support)

### DIFF
--- a/resources/sts/4.14/fedramp-hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/fedramp-hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -205,22 +205,6 @@
       }
     },
     {
-      "Sid": "NodePoolSQSActions",
-      "Effect": "Allow",
-      "Action": [
-        "sqs:DeleteMessage",
-        "sqs:ReceiveMessage"
-      ],
-      "Resource": [
-        "arn:aws-us-gov:sqs:*:*:*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/red-hat": "true"
-        }
-      }
-    },
-    {
       "Sid": "ManagedKMSRestrictedResourceTag",
       "Effect": "Allow",
       "Action": [

--- a/resources/sts/4.14/fedramp-hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/fedramp-hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -205,6 +205,22 @@
       }
     },
     {
+      "Sid": "NodePoolSQSActions",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:ReceiveMessage"
+      ],
+      "Resource": [
+        "arn:aws-us-gov:sqs:*:*:*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
       "Sid": "ManagedKMSRestrictedResourceTag",
       "Effect": "Allow",
       "Action": [

--- a/resources/sts/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -222,6 +222,22 @@
       }
     },
     {
+      "Sid": "NodePoolSQSActions",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:ReceiveMessage"
+      ],
+      "Resource": [
+        "arn:aws:sqs:*:*:*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
       "Sid": "ManagedKMSRestrictedResourceTag",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
Summary

- Adds `sqs:ReceiveMessage` and `sqs:DeleteMessage` permissions to the `ROSANodePoolManagementPolicy` (`openshift_hcp_capa_controller_manager_credentials_policy.json`) for both commercial and FedRAMP partitions.
- Permissions are scoped with `aws:ResourceTag/red-hat: true` condition to restrict access to Red Hat-managed SQS queues only.

Context

ROSA HCP is adding Spot instance support for NodePools. The AWS Node Termination Handler (NTH) needs to long-poll an SQS queue for EC2 spot interruption and rebalance recommendation events, and remove processed messages after acting on them. Without these permissions in the managed policy, the NTH deployment will fail to poll the SQS queue and spot interruption events will not be handled gracefully.

This MCC change is the source of truth for what gets submitted to AWS to publish a new version of `ROSANodePoolManagementPolicy`. A companion HyperShift PR keeps the inline (dev/test) policies in sync.

## Test plan

- [x] JSON validity confirmed for both commercial and FedRAMP policy files
- [x] Actions (`sqs:DeleteMessage`, `sqs:ReceiveMessage`) present in both variants
- [x] ARN partitions correct — commercial uses `arn:aws:sqs`, FedRAMP uses `arn:aws-us-gov:sqs`
- [x] Tag condition (`aws:ResourceTag/red-hat: true`) present and identical in both variants
- [x] No duplicate Sids in either policy

References

- Jira: [ROSAENG-906](https://redhat.atlassian.net/browse/ROSAENG-906)
- Parent initiative: [OCPSTRAT-1677](https://redhat.atlassian.net/browse/OCPSTRAT-1677)
- Enhancement: https://github.com/openshift/enhancements/pull/1951
- Companion HyperShift PR (inline policy sync): https://github.com/openshift/hypershift/pull/8134
- HyperShift implementation: https://github.com/openshift/hypershift/pull/7567
- HyperShift API changes: https://github.com/openshift/hypershift/pull/7625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IAM permissions for HyperShift node pool controllers to support Amazon SQS message operations with conditional resource tagging. Changes applied to both standard AWS and AWS GovCloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->