### PR TITLE
Correct the SID name for EBS CSI policy

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -99,7 +99,7 @@
       }
     },
     {
-      "Sid": "AttachDetachVolumesToAnyInstance",
+      "Sid": "AttachDetachVolumesToManagedInstances",
       "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",


### PR DESCRIPTION
### What type of PR is this?
Chore

### What this PR does / why we need it?

Change the SID name from "AnyInstance" to "ManagedInstances" to reflect the actual purpose.

The `AttachVolume` and `DetachVolume` are targeting the instances with the `red-hat-managed` tag. It is not "AnyInstance" but "ManagedInstances", to follow the same pattern of other SIDs.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal policy statement label to better reflect managed instances. No user-facing behavior or permissions changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->