### PR TITLE
feat(cert-manager): Add KSM metrics for Challenge CRs

### DIFF
--- a/deploy/hypershift-kube-state-metrics/025-configmap.yaml
+++ b/deploy/hypershift-kube-state-metrics/025-configmap.yaml
@@ -173,3 +173,30 @@ data:
                 type: Gauge
                 gauge:
                   path: [metadata, creationTimestamp]
+        # ---- cert-manager Challenge CRs ----
+        - groupVersionKind:
+            group: acme.cert-manager.io
+            version: v1
+            kind: Challenge
+          metricNamePrefix: certmanager_challenge_cr
+          labelsFromPath:
+            challenge_name:
+              - metadata
+              - name
+            exported_namespace:
+              - metadata
+              - namespace
+          metrics:
+            - name: "created"
+              help: "Creation timestamp of cert-manager Challenge CR."
+              each:
+                type: Gauge
+                gauge:
+                  path: [metadata, creationTimestamp]
+            - name: "info"
+              help: "cert-manager Challenge CR with state label."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    state: [status, state]

--- a/deploy/hypershift-kube-state-metrics/040-clusterrole.yaml
+++ b/deploy/hypershift-kube-state-metrics/040-clusterrole.yaml
@@ -46,3 +46,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30014,7 +30014,18 @@ objects:
           \          - metadata\n          - namespace\n      metrics:\n        -\
           \ name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshot\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
-          \      gauge:\n              path: [metadata, creationTimestamp]"
+          \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
+          \ ---- cert-manager Challenge CRs ----\n    - groupVersionKind:\n      \
+          \  group: acme.cert-manager.io\n        version: v1\n        kind: Challenge\n\
+          \      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]"
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -30066,6 +30077,14 @@ objects:
         resources:
         - volumesnapshotcontents
         - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30014,7 +30014,18 @@ objects:
           \          - metadata\n          - namespace\n      metrics:\n        -\
           \ name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshot\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
-          \      gauge:\n              path: [metadata, creationTimestamp]"
+          \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
+          \ ---- cert-manager Challenge CRs ----\n    - groupVersionKind:\n      \
+          \  group: acme.cert-manager.io\n        version: v1\n        kind: Challenge\n\
+          \      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]"
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -30066,6 +30077,14 @@ objects:
         resources:
         - volumesnapshotcontents
         - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30014,7 +30014,18 @@ objects:
           \          - metadata\n          - namespace\n      metrics:\n        -\
           \ name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshot\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
-          \      gauge:\n              path: [metadata, creationTimestamp]"
+          \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
+          \ ---- cert-manager Challenge CRs ----\n    - groupVersionKind:\n      \
+          \  group: acme.cert-manager.io\n        version: v1\n        kind: Challenge\n\
+          \      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]"
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -30066,6 +30077,14 @@ objects:
         resources:
         - volumesnapshotcontents
         - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
         verbs:
         - get
         - list


### PR DESCRIPTION
Configures kube-state-metrics to track `acme.cert-manager.io/v1` `Challenge` Custom Resources. This is required for alert rules monitoring challenge queue saturation and stale challenges, as the native cert-manager challenge metrics are not available in the currently deployed versions.

Adds two metrics:
- `certmanager_challenge_cr_created`: Gauge tracking the creation timestamp.
- `certmanager_challenge_cr_info`: Info metric exposing the `state` label from `status.state` (e.g., pending, processing).

Also grants the kube-state-metrics ClusterRole `get`, `list`, `watch` access to `challenges` in the `acme.cert-manager.io` API group.

Related to: [ROSAENG-3733](https://redhat.atlassian.net/browse/ROSAENG-3733)

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting metrics from cert-manager Challenge resources, including creation time and current state.
  * Expanded kube-state-metrics coverage for snapshot-related resources.

* **Bug Fixes**
  * Updated snapshot metrics configuration to normalize the VolumeSnapshot metric definition.
  * Extended permissions so the metrics system can watch additional resource types for more complete data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->