### PR TITLE
[ROSAENG-2104] Promote managed boot images rollout to production

### DIFF
--- a/deploy/osd-machine-configuration/osd-aws-419/config.yaml
+++ b/deploy/osd-machine-configuration/osd-aws-419/config.yaml
@@ -2,9 +2,6 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: "Sync"
   matchExpressions:
-  - key: api.openshift.com/environment
-    operator: In
-    values: ["integration", "staging"]
   - key: hive.openshift.io/version-major-minor
     operator: NotIn
     values: ["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -41531,11 +41531,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/environment
-        operator: In
-        values:
-        - integration
-        - staging
       - key: hive.openshift.io/version-major-minor
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -41531,11 +41531,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/environment
-        operator: In
-        values:
-        - integration
-        - staging
       - key: hive.openshift.io/version-major-minor
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -41531,11 +41531,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/environment
-        operator: In
-        values:
-        - integration
-        - staging
       - key: hive.openshift.io/version-major-minor
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Removes the environment restriction from the osd-aws-419 SelectorSyncSet,
promoting the managed boot images rollout to all environments including production.

The osd-aws-419 SelectorSyncSet patches spec.managedBootImages to null on
existing AWS OSD 4.19+ clusters, clearing the stale patch left behind by Hive
and allowing MCO to manage boot images. This is wave 2 of the [ROSAENG-2104](https://redhat.atlassian.net/browse/ROSAENG-2104)
rollout following PR #2788.

Validation results:
- Integration (cs-ci-tpdg2, AWS OSD 4.20): spec.managedBootImages unset,
  Reconciled 2 of 2 MAPI MachineSets ✓
- Stage (ci-osd-aws-3a6w, AWS OSD): spec.managedBootImages unset,
  Reconciled 9 of 9 MAPI MachineSets ✓

### Which Jira/Github issue(s) this PR fixes?
https://redhat.atlassian.net/browse/ROSAENG-2104

### Special notes for your reviewer:
This is the final step in a phased rollout:
- PR #2781 (merged): scoped the disable to ROSA only, added 4.18 OSD disable
- PR #2788 (merged): added osd-aws-419 SelectorSyncSet, integration-only
- PR #2803 (merged): promoted to stage
- This PR: promotes to production

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] If this is a new object that is not intended for the FedRAMP environment,
  please exclude it with:
  matchExpressions:
  - key: api.openshift.com/fedramp
    operator: NotIn
    values: ["true"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment selection rules so the configuration now applies without the previous environment-specific restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->