### PR TITLE
ROSAENG-1325: Tighten the KMS operations for ROSAAmazonEBSCSIDriverOperatorPolicy

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -9,6 +9,7 @@
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeSnapshots",
+        "ec2:DescribeTags",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVolumeStatus"
@@ -184,6 +185,9 @@
         },
         "StringLike": {
           "kms:ViaService": "ec2.*.amazonaws.com"
+        },
+        "ForAllValues:StringEquals": {
+          "kms:EncryptionContextKeys": ["aws:ebs:id"]
         }
       }
     },
@@ -200,6 +204,13 @@
         },
         "StringLike": {
           "kms:ViaService": "ec2.*.amazonaws.com"
+        },
+        "StringEquals": {
+          "kms:GrantConstraintType": "EncryptionContextSubset"
+        },
+        "ForAllValues:StringEquals": {
+          "kms:GrantOperations": ["Decrypt", "GenerateDataKeyWithoutPlaintext"],
+          "kms:EncryptionContextKeys": ["aws:ebs:id"]
         }
       }
     }

--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -186,6 +186,9 @@
         "StringLike": {
           "kms:ViaService": "ec2.*.amazonaws.com"
         },
+        "Null": {
+          "kms:EncryptionContextKeys": false
+        },
         "ForAllValues:StringEquals": {
           "kms:EncryptionContextKeys": ["aws:ebs:id"]
         }
@@ -207,6 +210,9 @@
         },
         "StringEquals": {
           "kms:GrantConstraintType": "EncryptionContextSubset"
+        },
+        "Null": {
+          "kms:EncryptionContextKeys": false
         },
         "ForAllValues:StringEquals": {
           "kms:GrantOperations": ["Decrypt", "GenerateDataKeyWithoutPlaintext"],


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This change is based on the review feedback from the AWS team.

This PR:
- Section `ReadOnlyDescribeOperations`. Add back the `ec2:DescribeTags` permission. The current in-use `ROSAAmazonEBSCSIDriverOperatorPolicy` has this permission. The previous [rebase PR](https://github.com/openshift/managed-cluster-config/pull/2670) removed this permission due to rebasing. There are still hypershift clusters which uses old version, we want the policy to be backward compatible thus we don't want to remove any existing permissions.
- Section `KMSEncryptedVolumes`. Add a condition `kms:EncryptionContextKeys = aws:ebs:id`.  This is to further scope the KMS action. From cloudtrail events, I can see the `GenerateDataKeyWithoutPlaintext` and `Decrypt` has this context key for EBS.
- Section `KMSCreateGrant`. Add a condition to scope `kms:GrantOperations` to the actions `Decrypt` and `GenerateDataKeyWithoutPlaintext`, which is the actions in this policy. Add a condition `kms:EncryptionContextKeys = aws:ebs:id` to scope it to EBS.


Reference:

https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-encryption-context-keys


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

I have validated the KMS action by the below steps:
- Create a 4.22 HCP clusters. (older version cluster should also work, the KMS permission is already missing, not related to EBS CSI rebase).
- Create a custom KMS key in the AWS account.
- Replace the policy for the ebs role to the policy in this PR. (Remove the default managed policy and add a custom policy).
- Create a storage class, PVC and pod:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-encrypted-custom-kms
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
parameters:
  type: gp3
  encrypted: "true"
  kmsKeyId:  <your-KMS-key-id>
```
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-encrypted-pvc
  namespace: default
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-encrypted-custom-kms
  resources:
    requests:
      storage: 10Gi
```
```
apiVersion: v1
kind: Pod
metadata:
  name: test-encrypted-pod
  namespace: default
spec:
  containers:
  - name: app
    image: busybox
    command: ["sleep", "3600"]
    volumeMounts:
    - mountPath: /data
      name: data
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: test-encrypted-pvc
```
- Create a snapshot class and snapshot:
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: ebs-snapshot-class
driver: ebs.csi.aws.com
deletionPolicy: Delete
```
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: ebs-volume-snapshot
  namespace: default
spec:
  volumeSnapshotClassName: ebs-snapshot-class
  source:
    persistentVolumeClaimName: test-encrypted-pvc
```
- Observe the AWS resources and cloudtrail.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened EBS/KMS access controls by tightening required encryption context keys for KMS operations.
  * Restricted KMS grant behavior to encryption-context-based grants and approved decrypt/data-key actions.
* **Bug Fixes**
  * Added missing EC2 tag description permissions to ensure complete resource metadata access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->