### PR TITLE
Refine KMS permissions for EBS CSI driver

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -176,7 +176,9 @@
       "Effect": "Allow",
       "Action": [
         "kms:Decrypt",
-        "kms:GenerateDataKeyWithoutPlaintext"
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:ReEncryptFrom",
+        "kms:ReEncryptTo"
       ],
       "Resource": "arn:aws:kms:*:*:key/*",
       "Condition": {
@@ -190,7 +192,9 @@
           "kms:EncryptionContextKeys": false
         },
         "ForAllValues:StringEquals": {
-          "kms:EncryptionContextKeys": ["aws:ebs:id"]
+          "kms:EncryptionContextKeys": [
+            "aws:ebs:id"
+          ]
         }
       }
     },
@@ -209,14 +213,36 @@
           "kms:ViaService": "ec2.*.amazonaws.com"
         },
         "StringEquals": {
-          "kms:GrantConstraintType": "EncryptionContextSubset"
+          "kms:GrantConstraintType": "EncryptionContextSubset",
+          "aws:ResourceTag/red-hat": "true"
         },
         "Null": {
           "kms:EncryptionContextKeys": false
         },
         "ForAllValues:StringEquals": {
-          "kms:GrantOperations": ["Decrypt", "GenerateDataKeyWithoutPlaintext"],
-          "kms:EncryptionContextKeys": ["aws:ebs:id"]
+          "kms:GrantOperations": [
+            "Decrypt",
+            "GenerateDataKeyWithoutPlaintext",
+            "ReEncryptFrom",
+            "ReEncryptTo"
+          ],
+          "kms:EncryptionContextKeys": [
+            "aws:ebs:id"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DescribeKMSKeysForEBSVolumeEncryption",
+      "Effect": "Allow",
+      "Action": "kms:DescribeKey",
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
         }
       }
     }


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This PR further refine the KMS related permissions for EBS driver.

This PR:
- Add resource tag condition to `KMSCreateGrant`.  Previously we missed the tag condition for the `CreateGrant` action. Adding the `aws:ResourceTag/red-hat = true` can scope it to key which customer allows red-hat to touch. This aligns other sections in this json file.
- Add actions `DescribeKey`, `ReEncryptFrom` and `ReEncryptTo`. These permissions are needed to create a volume from an encrypted snapshot.   https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption-requirements.html 


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

#### Tag condition

To validate the condition `aws:ResourceTag/red-hat = true` for `CreateGrant`, we can use the below steps.

Setup the environment:
- Create a HCP cluster on staging. I used a 4.22.1 cluster, this should also apply on an older version of cluster.
- Replace the EBS IAM role policy to the policy in this PR. (Removed the original ROSAAmazonEBSCSIDriverOperatorPolicy from the role, and attach a custom policy).
- Add a custom KMS key in the same AWS region.
- Create a StorageClass and VolumeSnapshotClass referring to the custom KMS key.
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-encrypted-custom-kms
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
parameters:
  type: gp3
  encrypted: "true"
  kmsKeyId: <custom-kms-key>
---
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: ebs-snapshot-class
driver: ebs.csi.aws.com
deletionPolicy: Delete
```

Case 1 - KMS key without red-hat tag.
- Remove the `red-hat` tag in the KMS key.
- Create a PVC and pod:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-encrypted-pvc
  namespace: default
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-encrypted-custom-kms
  resources:
    requests:
      storage: 10Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: test-encrypted-pod
  namespace: default
spec:
  containers:
  - name: app
    image: busybox
    command: ["sleep", "3600"]
    volumeMounts:
    - mountPath: /data
      name: data
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: test-encrypted-pvc
```
- Observe the PVC and pod resources, they will stuck in pending. Observe cloudtrail, the CreateVolume event will fail silently.

Case 2 - With the red-hat tag.
- Add back the `red-hat: true` tag to the KMS key.
- Wait and observe. The PVC and pod provision successfully. Cloudtrail has `CreateVolume` and `CreateGrant` event without error.


#### DescribeKey and ReEncrypt

Steps to verify.
- Setup the environment as the above section.
- Create a snapshot.
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: ebs-volume-snapshot
  namespace: default
spec:
  volumeSnapshotClassName: ebs-snapshot-class
  source:
    persistentVolumeClaimName: test-encrypted-pvc
```
- Remove the DescribeKey and ReEncrypt permission from the policy.
- Create a PVC which is restored from the snapshot, and create a pod to use the PVC.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: restored-ebs-pvc
  namespace: default
spec:
  storageClassName: ebs-encrypted-custom-kms
  dataSource:
    name: ebs-volume-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi # Must be equal to or greater than the snapshot's restoreSize
---
apiVersion: v1
kind: Pod
metadata:
  name: test-restored-pod
  namespace: default
spec:
  containers:
  - name: app
    image: busybox
    command: ["sleep", "3600"]
    volumeMounts:
    - mountPath: /data
      name: data
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: restored-ebs-pvc
```
- Observe. We can see the PVC and pod stuck in Pending. In Cloudtrail, the `CreateVolume` event failed silently (event has no issue, but the volume it creates won't exist).
- Add the permissions DescribeKey and ReEncrypt.
- Wait and observe. The PVC and pod can be created successfully. No error in cloudtrail.


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated encrypted EBS storage permissions to support additional KMS re-encryption operations.
  * Expanded and refined KMS grant permissions and encryption-context validation to better align with required encrypted-volume workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->