### PR TITLE
Update OWNERS_ALIASES and streamline not needed per-directory OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,26 +1,18 @@
 reviewers:
 - srep-functional-leads
-- srep-team-leads
+- rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.
-# If you feel like you should be part of this group, create a PR and ping TLs.
-- clcollins
-- robotmaxtron
-- typeid
+# If you feel like you should be part of this group, create a PR and ping rosa-staff-engineers.
 - xiaoyu74
 - zmird-r
 - cjnovak98
-- joshbranham
 approvers:
 - srep-functional-leads
-- srep-team-leads
+- rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.
-# If you feel like you should be part of this group, create a PR and ping TLs.
-- clcollins
-- robotmaxtron
-- typeid
+# If you feel like you should be part of this group, create a PR and ping rosa-staff-engineers.
 - xiaoyu74
 - zmird-r
 - cjnovak98
-- joshbranham

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,16 +16,29 @@ aliases:
     - smarthall
     - sam-nguyen7
     - ravitri
-  srep-team-leads:
-    - rafael-azevedo
-    - rogbas
-    - dustman9000
-    - bmeng
-    - typeid
   sre-alert-sme:
     - ravitri
     - jeremyeder
     - boranx
     - rogbas
   rosa-staff-engineers:
+    - Ajpantuso
+    - bergmannf
+    - bmeng
+    - bpresnel-rh
+    - cdoan1
+    - clcollins
+    - dustman9000
+    - joshbranham
     - jmelis
+    - lucasponce
+    - psav
+    - rafael-azevedo
+    - ravitri
+    - rbhilare
+    - robpblake
+    - smarthall
+    - syed
+    - theautoroboto
+    - tiwillia
+    - typeid

--- a/deploy/backplane/OWNERS
+++ b/deploy/backplane/OWNERS
@@ -1,6 +1,0 @@
-reviewers:
-- srep-functional-leads
-- srep-team-leads
-approvers:
-- srep-team-leads
-- rosa-staff-engineers

--- a/docs/backplane/OWNERS
+++ b/docs/backplane/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- rosa-staff-engineers
-options:
-  no_parent_owners: true

--- a/docs/backplane/requirements/hybridsre-hcp/OWNERS
+++ b/docs/backplane/requirements/hybridsre-hcp/OWNERS
@@ -1,6 +1,0 @@
-reviewers:
-- celebdor
-approvers:
-- rosa-staff-engineers
-options:
-  no_parent_owners: true

--- a/docs/backplane/requirements/srep/OWNERS
+++ b/docs/backplane/requirements/srep/OWNERS
@@ -1,6 +1,0 @@
-reviewers:
-- srep-functional-leads
-- srep-team-leads
-approvers:
-- srep-team-leads
-- rosa-staff-engineers

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,8 +1,0 @@
-reviewers:
-- srep-region-leads
-- srep-functional-leads
-- srep-team-leads
-approvers:
-- srep-region-leads
-- srep-team-leads
-- rosa-staff-engineers


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
We have a lot of OWNERS_ALIASES that weren't up to date, and per-directory OWNERS files that just duplicated what the root OWNERS had.

This cleans those up, and updates the aliases. I stumbled upon this when trying to approve HyperShift managed policy changes and not being able to all of a sudden. …files

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments and reviewer/approver rosters.
  * Expanded staff engineer and alert subject-matter expert aliases.
  * Removed outdated team and individual ownership references.
  * Cleared ownership metadata from selected deployment and documentation areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->