### PR TITLE
ROSAENG-61928: Add a new alert to track how many days of metrics we keep in platform.

### DIFF
--- a/deploy/sre-prometheus/100-platform-metrics-retention.yaml
+++ b/deploy/sre-prometheus/100-platform-metrics-retention.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-k8s-prometheus-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: prometheus
+    rules:
+    - alert: ShortEstimatedMetricsRetentionSRE
+      annotations:
+        description: A Prometheus PVC can only store an estimate of less than 5 days of metrics.
+        summary: Estimated metrics retention low on a prometheus PVC
+      expr: |
+        # Based on https://access.redhat.com/solutions/7134117
+        # 1. Dynamically inject a "pod" label into the capacity metric based on the PVC name
+        label_replace(
+          kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"prometheus-data-prometheus-k8s-[0-9]+"},
+          "pod", "$1", "persistentvolumeclaim", "prometheus-data-(.*)"
+        )
+        / on(pod) group_left()
+        (
+          # 2. Calculate daily ingestion rate (in Bytes) grouped by pod
+          1.2 * 86400 * (
+            sum by (pod) (rate(prometheus_tsdb_head_samples_appended_total{type="float", pod=~"prometheus-k8s-[0-9]+"}[1d]))
+            *
+            sum by (pod) (rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{pod=~"prometheus-k8s-[0-9]+"}[1d]))
+            /
+            sum by (pod) (rate(prometheus_tsdb_compaction_chunk_samples_sum{pod=~"prometheus-k8s-[0-9]+"}[1d]))
+          )
+        )
+        # We would use up all storage in less than 5 days leading to rotation.
+        < 5
+      for: 60m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47441,6 +47441,36 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
+        name: prometheus-k8s-prometheus-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: prometheus
+          rules:
+          - alert: ShortEstimatedMetricsRetentionSRE
+            annotations:
+              description: A Prometheus PVC can only store an estimate of less than
+                5 days of metrics.
+              summary: Estimated metrics retention low on a prometheus PVC
+            expr: "# Based on https://access.redhat.com/solutions/7134117\n# 1. Dynamically\
+              \ inject a \"pod\" label into the capacity metric based on the PVC name\n\
+              label_replace(\n  kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"\
+              prometheus-data-prometheus-k8s-[0-9]+\"},\n  \"pod\", \"$1\", \"persistentvolumeclaim\"\
+              , \"prometheus-data-(.*)\"\n)\n/ on(pod) group_left()\n(\n  # 2. Calculate\
+              \ daily ingestion rate (in Bytes) grouped by pod\n  1.2 * 86400 * (\n\
+              \    sum by (pod) (rate(prometheus_tsdb_head_samples_appended_total{type=\"\
+              float\", pod=~\"prometheus-k8s-[0-9]+\"}[1d]))\n    *\n    sum by (pod)\
+              \ (rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{pod=~\"prometheus-k8s-[0-9]+\"\
+              }[1d]))\n    /\n    sum by (pod) (rate(prometheus_tsdb_compaction_chunk_samples_sum{pod=~\"\
+              prometheus-k8s-[0-9]+\"}[1d]))\n  )\n)\n# We would use up all storage\
+              \ in less than 5 days leading to rotation.\n< 5\n"
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
         labels:
           prometheus: sre-pull-secret-health-alerts
           role: alert-rules

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47441,6 +47441,36 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
+        name: prometheus-k8s-prometheus-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: prometheus
+          rules:
+          - alert: ShortEstimatedMetricsRetentionSRE
+            annotations:
+              description: A Prometheus PVC can only store an estimate of less than
+                5 days of metrics.
+              summary: Estimated metrics retention low on a prometheus PVC
+            expr: "# Based on https://access.redhat.com/solutions/7134117\n# 1. Dynamically\
+              \ inject a \"pod\" label into the capacity metric based on the PVC name\n\
+              label_replace(\n  kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"\
+              prometheus-data-prometheus-k8s-[0-9]+\"},\n  \"pod\", \"$1\", \"persistentvolumeclaim\"\
+              , \"prometheus-data-(.*)\"\n)\n/ on(pod) group_left()\n(\n  # 2. Calculate\
+              \ daily ingestion rate (in Bytes) grouped by pod\n  1.2 * 86400 * (\n\
+              \    sum by (pod) (rate(prometheus_tsdb_head_samples_appended_total{type=\"\
+              float\", pod=~\"prometheus-k8s-[0-9]+\"}[1d]))\n    *\n    sum by (pod)\
+              \ (rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{pod=~\"prometheus-k8s-[0-9]+\"\
+              }[1d]))\n    /\n    sum by (pod) (rate(prometheus_tsdb_compaction_chunk_samples_sum{pod=~\"\
+              prometheus-k8s-[0-9]+\"}[1d]))\n  )\n)\n# We would use up all storage\
+              \ in less than 5 days leading to rotation.\n< 5\n"
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
         labels:
           prometheus: sre-pull-secret-health-alerts
           role: alert-rules

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47441,6 +47441,36 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
+        name: prometheus-k8s-prometheus-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: prometheus
+          rules:
+          - alert: ShortEstimatedMetricsRetentionSRE
+            annotations:
+              description: A Prometheus PVC can only store an estimate of less than
+                5 days of metrics.
+              summary: Estimated metrics retention low on a prometheus PVC
+            expr: "# Based on https://access.redhat.com/solutions/7134117\n# 1. Dynamically\
+              \ inject a \"pod\" label into the capacity metric based on the PVC name\n\
+              label_replace(\n  kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"\
+              prometheus-data-prometheus-k8s-[0-9]+\"},\n  \"pod\", \"$1\", \"persistentvolumeclaim\"\
+              , \"prometheus-data-(.*)\"\n)\n/ on(pod) group_left()\n(\n  # 2. Calculate\
+              \ daily ingestion rate (in Bytes) grouped by pod\n  1.2 * 86400 * (\n\
+              \    sum by (pod) (rate(prometheus_tsdb_head_samples_appended_total{type=\"\
+              float\", pod=~\"prometheus-k8s-[0-9]+\"}[1d]))\n    *\n    sum by (pod)\
+              \ (rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{pod=~\"prometheus-k8s-[0-9]+\"\
+              }[1d]))\n    /\n    sum by (pod) (rate(prometheus_tsdb_compaction_chunk_samples_sum{pod=~\"\
+              prometheus-k8s-[0-9]+\"}[1d]))\n  )\n)\n# We would use up all storage\
+              \ in less than 5 days leading to rotation.\n< 5\n"
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
         labels:
           prometheus: sre-pull-secret-health-alerts
           role: alert-rules


### PR DESCRIPTION
For some high velocity cluster we can have a limited day of metrics, so we need to get a feel how common this might be. 
If we drop low enough this might impact alerting rules requiring long 'for' windows.

### What type of PR is this?
feature

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROSAENG-61928](https://redhat.atlassian.net/browse/ROSAENG-61928)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a monitoring alert that warns when Prometheus metrics retention/storage capacity is projected to be exhausted within five days.
  * The alert triggers after the condition persists for 60 minutes and provides contextual guidance via summary and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->