### PR TITLE
Do not use prometheus group name.

### DIFF
--- a/deploy/sre-prometheus/100-platform-metrics-retention.yaml
+++ b/deploy/sre-prometheus/100-platform-metrics-retention.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
-  - name: prometheus
+  - name: sre-platform-metrics-retention
     rules:
     - alert: ShortEstimatedMetricsRetentionSRE
       annotations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47445,7 +47445,7 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: prometheus
+        - name: sre-platform-metrics-retention
           rules:
           - alert: ShortEstimatedMetricsRetentionSRE
             annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47445,7 +47445,7 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: prometheus
+        - name: sre-platform-metrics-retention
           rules:
           - alert: ShortEstimatedMetricsRetentionSRE
             annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47445,7 +47445,7 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: prometheus
+        - name: sre-platform-metrics-retention
           rules:
           - alert: ShortEstimatedMetricsRetentionSRE
             annotations:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the platform metrics retention monitoring configuration with a clearer rule group name.
  * Alert rules and evaluation logic remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->