### PR TITLE
RFE-9585: Enable enableUserAlertmanagerConfig in cluster-monitoring-config baseline

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/4.11-4.15/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/4.11-4.15/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config/4.11-4.15/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/4.11-4.15/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -48,6 +48,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -23,6 +23,7 @@ data:
             requests:
               storage: 100Gi
     alertmanagerMain:
+      enableUserAlertmanagerConfig: true
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28793,16 +28793,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28869,16 +28870,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28939,16 +28941,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29001,16 +29004,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29071,16 +29075,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29141,16 +29146,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29219,16 +29225,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29293,16 +29300,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29368,16 +29376,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -39533,12 +39542,13 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
           \ 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n    metadata:\n  \
           \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28793,16 +28793,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28869,16 +28870,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28939,16 +28941,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29001,16 +29004,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29071,16 +29075,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29141,16 +29146,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29219,16 +29225,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29293,16 +29300,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29368,16 +29376,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -39533,12 +39542,13 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
           \ 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n    metadata:\n  \
           \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28793,16 +28793,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28869,16 +28870,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -28939,16 +28941,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29001,16 +29004,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29071,16 +29075,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29141,16 +29146,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29219,16 +29225,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29293,16 +29300,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -29368,16 +29376,17 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -39533,12 +39542,13 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
           \ 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n    metadata:\n  \
           \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  enableUserAlertmanagerConfig:\
+          \ true\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n\
+          \  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\

--- a/resources/cluster-monitoring-config/config.yaml
+++ b/resources/cluster-monitoring-config/config.yaml
@@ -44,6 +44,9 @@ prometheusK8s:
         requests:
           storage: 100Gi
 alertmanagerMain:
+  # RFE-9585: durable platform AlertmanagerConfig merge for customer alert routing.
+  # Applies only when UWM Alertmanager is disabled (CMO).
+  enableUserAlertmanagerConfig: true
   nodeSelector:
     node-role.kubernetes.io/infra: ""
   tolerations:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Adds `alertmanagerMain.enableUserAlertmanagerConfig: true` to the Hive-managed `cluster-monitoring-config` baseline so ROSA/OSD customers can durably route platform `kube_*` / `Kube*` alerts to customer email/webhook receivers via `AlertmanagerConfig` CRs.

Today the setting is valid and supported by CMO, but the fleet template omits it. Manual edits to `cluster-monitoring-config` are removed on Hive SyncSet reconcile (~2h).

**Customer impact:** After fleet rollout, customers can keep using platform Alertmanager for platform alert routing without the config being overwritten.

**Important usage note (CMO):** `enableUserAlertmanagerConfig` only applies when the dedicated UWM Alertmanager is **disabled** (`alertmanager.enabled: false` / omitted in `user-workload-monitoring-config`). If UWM Alertmanager is enabled, CMO does not merge user `AlertmanagerConfig` into platform Alertmanager (verified on OCP 4.21).

### Which Jira/Github issue(s) this PR fixes?

Fixes https://redhat.atlassian.net/browse/RFE-9585

### Special notes for your reviewer:

- Source change: `resources/cluster-monitoring-config/config.yaml`
- Regenerated via `python3 scripts/generate-cmo-config.py` (all UWM / non-UWM / FedRAMP variants)
- Does not edit `alertmanager-main` secret or SRE `configure-alertmanager-operator` routes
- No alert routing changes until a customer creates an `AlertmanagerConfig` CR
- Recommended customer path: disable UWM Alertmanager, enable this flag (now fleet-durable), create `AlertmanagerConfig` for email/webhook

