### PR TITLE
ROSAENG-13689 | feat: update wif templates

### DIFF
--- a/resources/wif/4.20/vanilla.yaml
+++ b/resources/wif/4.20/vanilla.yaml
@@ -288,6 +288,11 @@ service_accounts:
       - id: iam.serviceAccountUser
         kind: Role
         predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
       - id: resourcemanager.tagUser
         kind: Role
         predefined: true

--- a/resources/wif/4.21/vanilla.yaml
+++ b/resources/wif/4.21/vanilla.yaml
@@ -288,6 +288,11 @@ service_accounts:
       - id: iam.serviceAccountUser
         kind: Role
         predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
       - id: resourcemanager.tagUser
         kind: Role
         predefined: true

--- a/resources/wif/4.22/vanilla.yaml
+++ b/resources/wif/4.22/vanilla.yaml
@@ -288,6 +288,11 @@ service_accounts:
       - id: iam.serviceAccountUser
         kind: Role
         predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
       - id: resourcemanager.tagUser
         kind: Role
         predefined: true


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
- Update v4.21 gcp-pd-csi-drier-op to use resource-scoped service account user role.
- Update v4.22 gcp-pd-csi-drier-op to use resource-scoped service account user role.

### Which Jira/Github issue(s) this PR fixes?
https://redhat.atlassian.net/browse/ROSAENG-13689

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated service account permissions for version 4.20 deployments.
  * Updated service account permissions for version 4.21 deployments.
  * Updated service account permissions for version 4.22 deployments.
  * Improved scoped access to worker and control-plane service account resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->