### PR TITLE
ROSAENG-61493 Enable RMO RouteMonitors and UrlMonitors in ROSA Govcloud

### DIFF
--- a/deploy/osd-route-monitor-operator/config.yaml
+++ b/deploy/osd-route-monitor-operator/config.yaml
@@ -1,10 +1,6 @@
 deploymentMode: SelectorSyncSet
 selectorSyncSet:
   matchExpressions:
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values:
-      - "true"
   - key: ext-hypershift.openshift.io/cluster-type
     operator: NotIn
     values: 

--- a/deploy/osd-route-monitor-operator/management-cluster/config.yaml
+++ b/deploy/osd-route-monitor-operator/management-cluster/config.yaml
@@ -1,10 +1,6 @@
 deploymentMode: SelectorSyncSet
 selectorSyncSet:
   matchExpressions:
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values:
-      - "true"
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -42892,10 +42892,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:
@@ -42938,10 +42934,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -42892,10 +42892,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:
@@ -42938,10 +42934,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -42892,10 +42892,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:
@@ -42938,10 +42934,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Enables the following for clusters in ROSA Govcloud:
- ClusterUrlMonitor for API
- RouteMonitor for Openshift Console

And the following for MCs in ROSA Govcloud:
- ClusterUrlMonitor for API

### Which Jira/Github issue(s) this PR fixes?

https://redhat.atlassian.net/browse/ROSAENG-61493

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster resource selection to include FedRAMP-labeled resources.
  * Preserved existing management-cluster and non-management-cluster filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->