### PR TITLE
chore(ROSAENG-62211): remove image-policy ICSPs from ROSA MCs

### DIFF
--- a/deploy/rosaeng-62211-delete-image-policy-icsp/00-Namespace.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/00-Namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rosaeng-62211-delete-image-policy-icsp

--- a/deploy/rosaeng-62211-delete-image-policy-icsp/01-ServiceAccount.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/01-ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-image-policy-icsp
+  namespace: rosaeng-62211-delete-image-policy-icsp

--- a/deploy/rosaeng-62211-delete-image-policy-icsp/02-ClusterRole.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/02-ClusterRole.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rosaeng-62211-delete-image-policy-icsp
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - imagecontentsourcepolicies
+  resourceNames:
+  - image-policy
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/rosaeng-62211-delete-image-policy-icsp/03-ClusterRoleBinding.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/03-ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rosaeng-62211-delete-image-policy-icsp
+subjects:
+- kind: ServiceAccount
+  name: delete-image-policy-icsp
+  namespace: rosaeng-62211-delete-image-policy-icsp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rosaeng-62211-delete-image-policy-icsp

--- a/deploy/rosaeng-62211-delete-image-policy-icsp/04-Job.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/04-Job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-image-policy-icsp
+  namespace: rosaeng-62211-delete-image-policy-icsp
+  annotations:
+    kubernetes.io/description: "ROSAENG-62211: Remove the image-policy ImageContentSourcePolicy from management and service clusters"
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      name: delete-image-policy-icsp
+    spec:
+      serviceAccountName: delete-image-policy-icsp
+      restartPolicy: Never
+      containers:
+      - name: delete-image-policy-icsp
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          ICSP="image-policy"
+
+          echo "=========================================="
+          echo "Delete image-policy ICSP - ROSAENG-62211"
+          echo "=========================================="
+          echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo ""
+
+          RESOURCE=$(oc get imagecontentsourcepolicy "${ICSP}" --ignore-not-found -o name 2>&1)
+
+          if [ -n "$RESOURCE" ]; then
+            echo "Found ${RESOURCE}, deleting..."
+
+            if oc delete imagecontentsourcepolicy "${ICSP}" --ignore-not-found; then
+              echo "Deletion successful"
+
+              sleep 3
+              VERIFY=$(oc get imagecontentsourcepolicy "${ICSP}" --ignore-not-found -o name 2>&1)
+
+              if [ -z "$VERIFY" ]; then
+                echo "Verified: ${ICSP} removed"
+              else
+                echo "ERROR: ${ICSP} still exists after deletion"
+                exit 1
+              fi
+            else
+              echo "ERROR: Failed to delete ${ICSP}"
+              exit 1
+            fi
+          else
+            echo "${ICSP} not found - nothing to do"
+          fi
+
+          echo ""
+          echo "Completed successfully"
+          echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/deploy/rosaeng-62211-delete-image-policy-icsp/config.yaml
+++ b/deploy/rosaeng-62211-delete-image-policy-icsp/config.yaml
@@ -1,0 +1,13 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values:
+      - "management-cluster"
+      - "service-cluster"
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -46435,6 +46435,112 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rosaeng-62211-delete-image-policy-icsp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        resourceNames:
+        - image-policy
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      subjects:
+      - kind: ServiceAccount
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+        annotations:
+          kubernetes.io/description: 'ROSAENG-62211: Remove the image-policy ImageContentSourcePolicy
+            from management and service clusters'
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: delete-image-policy-icsp
+          spec:
+            serviceAccountName: delete-image-policy-icsp
+            restartPolicy: Never
+            containers:
+            - name: delete-image-policy-icsp
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nICSP=\"image-policy\"\n\necho \"\
+                ==========================================\"\necho \"Delete image-policy\
+                \ ICSP - ROSAENG-62211\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                RESOURCE=$(oc get imagecontentsourcepolicy \"${ICSP}\" --ignore-not-found\
+                \ -o name 2>&1)\n\nif [ -n \"$RESOURCE\" ]; then\n  echo \"Found ${RESOURCE},\
+                \ deleting...\"\n\n  if oc delete imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found; then\n    echo \"Deletion successful\"\n\n \
+                \   sleep 3\n    VERIFY=$(oc get imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found -o name 2>&1)\n\n    if [ -z \"$VERIFY\" ]; then\n\
+                \      echo \"Verified: ${ICSP} removed\"\n    else\n      echo \"\
+                ERROR: ${ICSP} still exists after deletion\"\n      exit 1\n    fi\n\
+                \  else\n    echo \"ERROR: Failed to delete ${ICSP}\"\n    exit 1\n\
+                \  fi\nelse\n  echo \"${ICSP} not found - nothing to do\"\nfi\n\n\
+                echo \"\"\necho \"Completed successfully\"\necho \"Timestamp: $(date\
+                \ -u +%Y-%m-%dT%H:%M:%SZ)\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosaeng-900-console-webhook-cleanup
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -46435,6 +46435,112 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rosaeng-62211-delete-image-policy-icsp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        resourceNames:
+        - image-policy
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      subjects:
+      - kind: ServiceAccount
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+        annotations:
+          kubernetes.io/description: 'ROSAENG-62211: Remove the image-policy ImageContentSourcePolicy
+            from management and service clusters'
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: delete-image-policy-icsp
+          spec:
+            serviceAccountName: delete-image-policy-icsp
+            restartPolicy: Never
+            containers:
+            - name: delete-image-policy-icsp
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nICSP=\"image-policy\"\n\necho \"\
+                ==========================================\"\necho \"Delete image-policy\
+                \ ICSP - ROSAENG-62211\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                RESOURCE=$(oc get imagecontentsourcepolicy \"${ICSP}\" --ignore-not-found\
+                \ -o name 2>&1)\n\nif [ -n \"$RESOURCE\" ]; then\n  echo \"Found ${RESOURCE},\
+                \ deleting...\"\n\n  if oc delete imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found; then\n    echo \"Deletion successful\"\n\n \
+                \   sleep 3\n    VERIFY=$(oc get imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found -o name 2>&1)\n\n    if [ -z \"$VERIFY\" ]; then\n\
+                \      echo \"Verified: ${ICSP} removed\"\n    else\n      echo \"\
+                ERROR: ${ICSP} still exists after deletion\"\n      exit 1\n    fi\n\
+                \  else\n    echo \"ERROR: Failed to delete ${ICSP}\"\n    exit 1\n\
+                \  fi\nelse\n  echo \"${ICSP} not found - nothing to do\"\nfi\n\n\
+                echo \"\"\necho \"Completed successfully\"\necho \"Timestamp: $(date\
+                \ -u +%Y-%m-%dT%H:%M:%SZ)\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosaeng-900-console-webhook-cleanup
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -46435,6 +46435,112 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rosaeng-62211-delete-image-policy-icsp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        resourceNames:
+        - image-policy
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: rosaeng-62211-delete-image-policy-icsp
+      subjects:
+      - kind: ServiceAccount
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: rosaeng-62211-delete-image-policy-icsp
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: delete-image-policy-icsp
+        namespace: rosaeng-62211-delete-image-policy-icsp
+        annotations:
+          kubernetes.io/description: 'ROSAENG-62211: Remove the image-policy ImageContentSourcePolicy
+            from management and service clusters'
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: delete-image-policy-icsp
+          spec:
+            serviceAccountName: delete-image-policy-icsp
+            restartPolicy: Never
+            containers:
+            - name: delete-image-policy-icsp
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nICSP=\"image-policy\"\n\necho \"\
+                ==========================================\"\necho \"Delete image-policy\
+                \ ICSP - ROSAENG-62211\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                RESOURCE=$(oc get imagecontentsourcepolicy \"${ICSP}\" --ignore-not-found\
+                \ -o name 2>&1)\n\nif [ -n \"$RESOURCE\" ]; then\n  echo \"Found ${RESOURCE},\
+                \ deleting...\"\n\n  if oc delete imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found; then\n    echo \"Deletion successful\"\n\n \
+                \   sleep 3\n    VERIFY=$(oc get imagecontentsourcepolicy \"${ICSP}\"\
+                \ --ignore-not-found -o name 2>&1)\n\n    if [ -z \"$VERIFY\" ]; then\n\
+                \      echo \"Verified: ${ICSP} removed\"\n    else\n      echo \"\
+                ERROR: ${ICSP} still exists after deletion\"\n      exit 1\n    fi\n\
+                \  else\n    echo \"ERROR: Failed to delete ${ICSP}\"\n    exit 1\n\
+                \  fi\nelse\n  echo \"${ICSP} not found - nothing to do\"\nfi\n\n\
+                echo \"\"\necho \"Completed successfully\"\necho \"Timestamp: $(date\
+                \ -u +%Y-%m-%dT%H:%M:%SZ)\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosaeng-900-console-webhook-cleanup
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?

Deploys a one-shot Job to Management and Service Clusters (non-FedRAMP) to delete the `image-policy` `ImageContentSourcePolicy`.

The Job:
- Runs once with `backoffLimit: 3` and `activeDeadlineSeconds: 300`
- Omits `ttlSecondsAfterFinished` so the completed Job persists indefinitely, preventing Hive from re-applying it
- Uses `resourceApplyMode: Sync` so all resources (namespace, RBAC, Job) can be cleaned up by removing the deploy directory after rollout

Resources created:
- `Namespace`: `rosaeng-62211-delete-image-policy-icsp`
- `ServiceAccount`: `delete-image-policy-icsp`
- `ClusterRole` / `ClusterRoleBinding`: scoped to `get`, `list`, `delete` on `imagecontentsourcepolicies` with `resourceNames: ["image-policy"]`
- `Job`: checks if the ICSP exists, deletes it if found, and verifies removal

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/ROSAENG-62211

### Special notes for your reviewer:

- The `ClusterRole` is restricted to the single resource name `image-policy` to follow least-privilege.
- No `ttlSecondsAfterFinished` is set intentionally -- an indefinite TTL prevents Hive from detecting the Job as "missing" and re-syncing it, which would cause repeated execution.
- After the change has rolled out to all targeted clusters, this deploy directory should be removed in a follow-up PR to clean up the namespace, RBAC, and completed Job.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an automated Kubernetes job to delete an `ImageContentSourcePolicy` named `image-policy` when it exists.
  * Includes a verification step to confirm the policy is removed, and exits successfully when it is already absent.
  * Configured the deployment to target eligible management and service clusters, excluding FedRAMP environments.
  * Added the required namespace and permissions for the cleanup job to run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->