### PR TITLE
Allow EBS CSI to act on user brought volume and snapshot

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -44,6 +44,19 @@
       }
     },
     {
+      "Sid": "CopyUserBroughtVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/vol-*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
       "Sid": "CreateSnapshotsWithManagedTag",
       "Effect": "Allow",
       "Action": [
@@ -70,6 +83,19 @@
       }
     },
     {
+      "Sid": "CreateSnapshotsFromUserBroughtVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
       "Sid": "ManageManagedVolumes",
       "Effect": "Allow",
       "Action": [
@@ -86,6 +112,22 @@
       }
     },
     {
+      "Sid": "ManageUserBroughtVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
       "Sid": "CreateVolumesFromAndEnableFSROnManagedSnapshots",
       "Effect": "Allow",
       "Action": [
@@ -96,6 +138,20 @@
       "Condition": {
         "StringEquals": {
           "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateVolumesFromAndEnableFSROnUserBroughtSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
         }
       }
     },
@@ -124,6 +180,20 @@
       "Condition": {
         "StringEquals": {
           "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "DeleteAndLockUserBroughtSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
         }
       }
     },
@@ -165,6 +235,31 @@
         "ForAllValues:StringNotEquals": {
           "aws:TagKeys": [
             "red-hat-managed",
+            "ebs.csi.aws.com/cluster",
+            "kubernetes.io/created-for/pvc/name"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ModifyTagsOnUserBroughtVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        },
+        "Null": {
+          "aws:TagKeys": "false"
+        },
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": [
+            "red-hat-managed",
+            "red-hat",
             "ebs.csi.aws.com/cluster",
             "kubernetes.io/created-for/pvc/name"
           ]


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Add IAM policy support for user-brought (adopted) EBS volumes and snapshots.

Previously, the IAM policy only allowed the CSI driver to operate on resources tagged with `red-hat-managed=true`, which is applied automatically by the CSI driver when it creates volumes and snapshots.

This prevented users from adopting pre-existing EBS resources (e.g. volumes/snapshots from AWS Backup, DLM, cross-account sharing, or manual creation) into their ROSA HCP cluster via static provisioning.

This change adds 6 new IAM statements that mirror existing ones but accept `red-hat=true` as an alternative authorization tag. Users who want to bring their own volume or snapshot must first tag it with `red-hat=true` using their own AWS credentials, which acts as an explicit grant of permission for the CSI driver to operate on it.

New statements:
- CopyUserBroughtVolumes
- CreateSnapshotsFromUserBroughtVolumes
- ManageUserBroughtVolumes (Attach/Detach/Modify/Delete)
- CreateVolumesFromAndEnableFSROnUserBroughtSnapshots
- DeleteAndLockUserBroughtSnapshots
- ModifyTagsOnUserBroughtVolumes

### Which Jira/Github issue(s) this PR fixes?

Addressing feedback.

### Special notes for your reviewer:

How to use a user brought volume:
- Create an AWS Volume with the red-hat tag, using the user's own AWS credential.
- Create a PV referencing the volume.
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: adopted-pv
spec:
  capacity:
    storage: 10Gi
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Delete
  storageClassName: "gp3-csi"
  csi:
    driver: ebs.csi.aws.com
    volumeHandle: vol-xxxxxxx
    fsType: ext4
  nodeAffinity:
    required:
      nodeSelectorTerms:
        - matchExpressions:
            - key: topology.ebs.csi.aws.com/zone
              operator: In
              values:
                - us-west-2a
```
- Create a PVC and pod that uses it.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: adopted-pvc
  namespace: default
spec:
  accessModes: [ReadWriteOnce]
  storageClassName: "gp3-csi"
  resources:
    requests:
      storage: 10Gi
  volumeName: adopted-pv
```
```
apiVersion: v1
kind: Pod
metadata:
  name: adopted-test-pod
  namespace: default
spec:
  containers:
  - name: test
    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
    command: ["sleep", "3600"]
    volumeMounts:
    - name: data
      mountPath: /data
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: adopted-pvc
```
- Delete the pod, pv, and pvc. We can see the AWS volume is also deleted. (retain policy = delete in this case).

How to use a user brought snapshot:
- Create a snapshot without the red-hat-managed tag.
- Create a VolumeSnapshotContent and VolumeSnapshot referencing it.
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotContent
metadata:
  name: imported-snapcontent
spec:
  deletionPolicy: Delete
  driver: ebs.csi.aws.com
  source:
    snapshotHandle: snap-xxxxxxx
  volumeSnapshotRef:
    name: imported-snapshot
    namespace: default
```
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: imported-snapshot
  namespace: default
spec:
  source:
    volumeSnapshotContentName: imported-snapcontent
```
- Create a PVC with dataSource referencing the VolumeSnapshot.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: restored-pvc
  namespace: default
spec:
  accessModes: [ReadWriteOnce]
  storageClassName: gp3-csi
  resources:
    requests:
      storage: 300Gi
  dataSource:
    name: imported-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
```
- Create a pod
```
apiVersion: v1
kind: Pod
metadata:
  name: snapshot-test-pod
  namespace: default
spec:
  containers:
  - name: test
    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
    command: ["sleep", "3600"]
    volumeMounts:
    - name: data
      mountPath: /data
  volumes:
  - name: data
    persistentVolumeClaim:
      claimName: restored-pvc
```
- Delete pod, pvc, snapshot.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for customer-provided EBS resources.
  * Added permissions for volume management, snapshots, fast snapshot restores, and resource tagging when resources carry the required identifying tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->