### PR TITLE
ROSAENG-62424 Add KSM metric for nodepool market type

### DIFF
--- a/deploy/hypershift-kube-state-metrics/025-configmap.yaml
+++ b/deploy/hypershift-kube-state-metrics/025-configmap.yaml
@@ -68,6 +68,13 @@ data:
                       payload_valid_reason: [status, conditions, "[type=ValidGeneratedPayload]", reason]
                       ign_server_reached: [status, conditions, "[type=ReachedIgnitionEndpoint]", status]
                       ign_server_reached_reason: [status, conditions, "[type=ReachedIgnitionEndpoint]", reason]
+            - name: "spec_info"
+              help: "Static spec-derived info for a nodepool"
+              each:
+                type: Info
+                info:
+                    labelsFromPath:
+                      market_type: [spec, platform, aws, placement, marketType]
         # ---- Velero Backup CRs ----
         # Two metrics needed because newly enqueued backups have status: {}
         # (no phase set yet), and KSM Info metrics are NOT emitted when the

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30747,44 +30747,48 @@ objects:
           , reason]\n                  ign_server_reached: [status, conditions, \"\
           [type=ReachedIgnitionEndpoint]\", status]\n                  ign_server_reached_reason:\
           \ [status, conditions, \"[type=ReachedIgnitionEndpoint]\", reason]\n   \
-          \ # ---- Velero Backup CRs ----\n    # Two metrics needed because newly\
-          \ enqueued backups have status: {}\n    # (no phase set yet), and KSM Info\
-          \ metrics are NOT emitted when the\n    # labelsFromPath path cannot resolve.\n\
-          \    #\n    # \"created\" (Gauge): always emits for every Backup CR \u2192\
-          \ gives total count.\n    # \"info\" (Info): only emits when status.phase\
-          \ exists \u2192 gives count by phase.\n    # Enqueued backups = count(created)\
-          \ - count(info).\n    - groupVersionKind:\n        group: velero.io\n  \
-          \      version: v1\n        kind: Backup\n      metricNamePrefix: velero_backup_cr\n\
-          \      labelsFromPath:\n        backup_name:\n          - metadata\n   \
-          \       - name\n        exported_namespace:\n          - metadata\n    \
-          \      - namespace\n      metrics:\n        - name: \"created\"\n      \
-          \    help: \"Creation timestamp of Velero backup CR (always emitted).\"\n\
-          \          each:\n            type: Gauge\n            gauge:\n        \
-          \      path: [metadata, creationTimestamp]\n        - name: \"info\"\n \
-          \         help: \"Velero backup CR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ Velero DeleteBackupRequest CRs ----\n    # Same pattern as Backups: most\
-          \ DBRs have status: {} while enqueued,\n    # only the one actively being\
-          \ processed has status.phase: InProgress.\n    # \"created\" gives total\
-          \ count, \"info\" gives count by phase.\n    - groupVersionKind:\n     \
-          \   group: velero.io\n        version: v1\n        kind: DeleteBackupRequest\n\
-          \      metricNamePrefix: velero_dbr_cr\n      labelsFromPath:\n        dbr_name:\n\
-          \          - metadata\n          - name\n        exported_namespace:\n \
-          \         - metadata\n          - namespace\n      metrics:\n        - name:\
-          \ \"created\"\n          help: \"Creation timestamp of Velero DBR (always\
-          \ emitted).\"\n          each:\n            type: Gauge\n            gauge:\n\
-          \              path: [metadata, creationTimestamp]\n        - name: \"info\"\
-          \n          help: \"Velero DBR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ VolumeSnapshotContent (cluster-scoped) ----\n    # With deletionPolicy=Delete,\
-          \ VSCs should not persist.\n    # Any existing VSC is an orphan from a stuck\
-          \ deletion.\n    # Signal: count > 0 = problem.\n    - groupVersionKind:\n\
-          \        group: snapshot.storage.k8s.io\n        version: v1\n        kind:\
-          \ VolumeSnapshotContent\n      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n\
-          \        vsc_name:\n          - metadata\n          - name\n      metrics:\n\
-          \        - name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
+          \     - name: \"spec_info\"\n          help: \"Static spec-derived info\
+          \ for a nodepool\"\n          each:\n            type: Info\n          \
+          \  info:\n                labelsFromPath:\n                  market_type:\
+          \ [spec, platform, aws, placement, marketType]\n    # ---- Velero Backup\
+          \ CRs ----\n    # Two metrics needed because newly enqueued backups have\
+          \ status: {}\n    # (no phase set yet), and KSM Info metrics are NOT emitted\
+          \ when the\n    # labelsFromPath path cannot resolve.\n    #\n    # \"created\"\
+          \ (Gauge): always emits for every Backup CR \u2192 gives total count.\n\
+          \    # \"info\" (Info): only emits when status.phase exists \u2192 gives\
+          \ count by phase.\n    # Enqueued backups = count(created) - count(info).\n\
+          \    - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: Backup\n      metricNamePrefix: velero_backup_cr\n      labelsFromPath:\n\
+          \        backup_name:\n          - metadata\n          - name\n        exported_namespace:\n\
+          \          - metadata\n          - namespace\n      metrics:\n        -\
+          \ name: \"created\"\n          help: \"Creation timestamp of Velero backup\
+          \ CR (always emitted).\"\n          each:\n            type: Gauge\n   \
+          \         gauge:\n              path: [metadata, creationTimestamp]\n  \
+          \      - name: \"info\"\n          help: \"Velero backup CR with phase label\
+          \ (only when phase exists).\"\n          each:\n            type: Info\n\
+          \            info:\n              labelsFromPath:\n                phase:\
+          \ [status, phase]\n    # ---- Velero DeleteBackupRequest CRs ----\n    #\
+          \ Same pattern as Backups: most DBRs have status: {} while enqueued,\n \
+          \   # only the one actively being processed has status.phase: InProgress.\n\
+          \    # \"created\" gives total count, \"info\" gives count by phase.\n \
+          \   - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: DeleteBackupRequest\n      metricNamePrefix: velero_dbr_cr\n\
+          \      labelsFromPath:\n        dbr_name:\n          - metadata\n      \
+          \    - name\n        exported_namespace:\n          - metadata\n       \
+          \   - namespace\n      metrics:\n        - name: \"created\"\n         \
+          \ help: \"Creation timestamp of Velero DBR (always emitted).\"\n       \
+          \   each:\n            type: Gauge\n            gauge:\n              path:\
+          \ [metadata, creationTimestamp]\n        - name: \"info\"\n          help:\
+          \ \"Velero DBR with phase label (only when phase exists).\"\n          each:\n\
+          \            type: Info\n            info:\n              labelsFromPath:\n\
+          \                phase: [status, phase]\n    # ---- VolumeSnapshotContent\
+          \ (cluster-scoped) ----\n    # With deletionPolicy=Delete, VSCs should not\
+          \ persist.\n    # Any existing VSC is an orphan from a stuck deletion.\n\
+          \    # Signal: count > 0 = problem.\n    - groupVersionKind:\n        group:\
+          \ snapshot.storage.k8s.io\n        version: v1\n        kind: VolumeSnapshotContent\n\
+          \      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n        vsc_name:\n\
+          \          - metadata\n          - name\n      metrics:\n        - name:\
+          \ \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
           \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
           \ ---- VolumeSnapshot (namespace-scoped) ----\n    # Same as VSC: should\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30747,44 +30747,48 @@ objects:
           , reason]\n                  ign_server_reached: [status, conditions, \"\
           [type=ReachedIgnitionEndpoint]\", status]\n                  ign_server_reached_reason:\
           \ [status, conditions, \"[type=ReachedIgnitionEndpoint]\", reason]\n   \
-          \ # ---- Velero Backup CRs ----\n    # Two metrics needed because newly\
-          \ enqueued backups have status: {}\n    # (no phase set yet), and KSM Info\
-          \ metrics are NOT emitted when the\n    # labelsFromPath path cannot resolve.\n\
-          \    #\n    # \"created\" (Gauge): always emits for every Backup CR \u2192\
-          \ gives total count.\n    # \"info\" (Info): only emits when status.phase\
-          \ exists \u2192 gives count by phase.\n    # Enqueued backups = count(created)\
-          \ - count(info).\n    - groupVersionKind:\n        group: velero.io\n  \
-          \      version: v1\n        kind: Backup\n      metricNamePrefix: velero_backup_cr\n\
-          \      labelsFromPath:\n        backup_name:\n          - metadata\n   \
-          \       - name\n        exported_namespace:\n          - metadata\n    \
-          \      - namespace\n      metrics:\n        - name: \"created\"\n      \
-          \    help: \"Creation timestamp of Velero backup CR (always emitted).\"\n\
-          \          each:\n            type: Gauge\n            gauge:\n        \
-          \      path: [metadata, creationTimestamp]\n        - name: \"info\"\n \
-          \         help: \"Velero backup CR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ Velero DeleteBackupRequest CRs ----\n    # Same pattern as Backups: most\
-          \ DBRs have status: {} while enqueued,\n    # only the one actively being\
-          \ processed has status.phase: InProgress.\n    # \"created\" gives total\
-          \ count, \"info\" gives count by phase.\n    - groupVersionKind:\n     \
-          \   group: velero.io\n        version: v1\n        kind: DeleteBackupRequest\n\
-          \      metricNamePrefix: velero_dbr_cr\n      labelsFromPath:\n        dbr_name:\n\
-          \          - metadata\n          - name\n        exported_namespace:\n \
-          \         - metadata\n          - namespace\n      metrics:\n        - name:\
-          \ \"created\"\n          help: \"Creation timestamp of Velero DBR (always\
-          \ emitted).\"\n          each:\n            type: Gauge\n            gauge:\n\
-          \              path: [metadata, creationTimestamp]\n        - name: \"info\"\
-          \n          help: \"Velero DBR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ VolumeSnapshotContent (cluster-scoped) ----\n    # With deletionPolicy=Delete,\
-          \ VSCs should not persist.\n    # Any existing VSC is an orphan from a stuck\
-          \ deletion.\n    # Signal: count > 0 = problem.\n    - groupVersionKind:\n\
-          \        group: snapshot.storage.k8s.io\n        version: v1\n        kind:\
-          \ VolumeSnapshotContent\n      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n\
-          \        vsc_name:\n          - metadata\n          - name\n      metrics:\n\
-          \        - name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
+          \     - name: \"spec_info\"\n          help: \"Static spec-derived info\
+          \ for a nodepool\"\n          each:\n            type: Info\n          \
+          \  info:\n                labelsFromPath:\n                  market_type:\
+          \ [spec, platform, aws, placement, marketType]\n    # ---- Velero Backup\
+          \ CRs ----\n    # Two metrics needed because newly enqueued backups have\
+          \ status: {}\n    # (no phase set yet), and KSM Info metrics are NOT emitted\
+          \ when the\n    # labelsFromPath path cannot resolve.\n    #\n    # \"created\"\
+          \ (Gauge): always emits for every Backup CR \u2192 gives total count.\n\
+          \    # \"info\" (Info): only emits when status.phase exists \u2192 gives\
+          \ count by phase.\n    # Enqueued backups = count(created) - count(info).\n\
+          \    - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: Backup\n      metricNamePrefix: velero_backup_cr\n      labelsFromPath:\n\
+          \        backup_name:\n          - metadata\n          - name\n        exported_namespace:\n\
+          \          - metadata\n          - namespace\n      metrics:\n        -\
+          \ name: \"created\"\n          help: \"Creation timestamp of Velero backup\
+          \ CR (always emitted).\"\n          each:\n            type: Gauge\n   \
+          \         gauge:\n              path: [metadata, creationTimestamp]\n  \
+          \      - name: \"info\"\n          help: \"Velero backup CR with phase label\
+          \ (only when phase exists).\"\n          each:\n            type: Info\n\
+          \            info:\n              labelsFromPath:\n                phase:\
+          \ [status, phase]\n    # ---- Velero DeleteBackupRequest CRs ----\n    #\
+          \ Same pattern as Backups: most DBRs have status: {} while enqueued,\n \
+          \   # only the one actively being processed has status.phase: InProgress.\n\
+          \    # \"created\" gives total count, \"info\" gives count by phase.\n \
+          \   - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: DeleteBackupRequest\n      metricNamePrefix: velero_dbr_cr\n\
+          \      labelsFromPath:\n        dbr_name:\n          - metadata\n      \
+          \    - name\n        exported_namespace:\n          - metadata\n       \
+          \   - namespace\n      metrics:\n        - name: \"created\"\n         \
+          \ help: \"Creation timestamp of Velero DBR (always emitted).\"\n       \
+          \   each:\n            type: Gauge\n            gauge:\n              path:\
+          \ [metadata, creationTimestamp]\n        - name: \"info\"\n          help:\
+          \ \"Velero DBR with phase label (only when phase exists).\"\n          each:\n\
+          \            type: Info\n            info:\n              labelsFromPath:\n\
+          \                phase: [status, phase]\n    # ---- VolumeSnapshotContent\
+          \ (cluster-scoped) ----\n    # With deletionPolicy=Delete, VSCs should not\
+          \ persist.\n    # Any existing VSC is an orphan from a stuck deletion.\n\
+          \    # Signal: count > 0 = problem.\n    - groupVersionKind:\n        group:\
+          \ snapshot.storage.k8s.io\n        version: v1\n        kind: VolumeSnapshotContent\n\
+          \      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n        vsc_name:\n\
+          \          - metadata\n          - name\n      metrics:\n        - name:\
+          \ \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
           \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
           \ ---- VolumeSnapshot (namespace-scoped) ----\n    # Same as VSC: should\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30747,44 +30747,48 @@ objects:
           , reason]\n                  ign_server_reached: [status, conditions, \"\
           [type=ReachedIgnitionEndpoint]\", status]\n                  ign_server_reached_reason:\
           \ [status, conditions, \"[type=ReachedIgnitionEndpoint]\", reason]\n   \
-          \ # ---- Velero Backup CRs ----\n    # Two metrics needed because newly\
-          \ enqueued backups have status: {}\n    # (no phase set yet), and KSM Info\
-          \ metrics are NOT emitted when the\n    # labelsFromPath path cannot resolve.\n\
-          \    #\n    # \"created\" (Gauge): always emits for every Backup CR \u2192\
-          \ gives total count.\n    # \"info\" (Info): only emits when status.phase\
-          \ exists \u2192 gives count by phase.\n    # Enqueued backups = count(created)\
-          \ - count(info).\n    - groupVersionKind:\n        group: velero.io\n  \
-          \      version: v1\n        kind: Backup\n      metricNamePrefix: velero_backup_cr\n\
-          \      labelsFromPath:\n        backup_name:\n          - metadata\n   \
-          \       - name\n        exported_namespace:\n          - metadata\n    \
-          \      - namespace\n      metrics:\n        - name: \"created\"\n      \
-          \    help: \"Creation timestamp of Velero backup CR (always emitted).\"\n\
-          \          each:\n            type: Gauge\n            gauge:\n        \
-          \      path: [metadata, creationTimestamp]\n        - name: \"info\"\n \
-          \         help: \"Velero backup CR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ Velero DeleteBackupRequest CRs ----\n    # Same pattern as Backups: most\
-          \ DBRs have status: {} while enqueued,\n    # only the one actively being\
-          \ processed has status.phase: InProgress.\n    # \"created\" gives total\
-          \ count, \"info\" gives count by phase.\n    - groupVersionKind:\n     \
-          \   group: velero.io\n        version: v1\n        kind: DeleteBackupRequest\n\
-          \      metricNamePrefix: velero_dbr_cr\n      labelsFromPath:\n        dbr_name:\n\
-          \          - metadata\n          - name\n        exported_namespace:\n \
-          \         - metadata\n          - namespace\n      metrics:\n        - name:\
-          \ \"created\"\n          help: \"Creation timestamp of Velero DBR (always\
-          \ emitted).\"\n          each:\n            type: Gauge\n            gauge:\n\
-          \              path: [metadata, creationTimestamp]\n        - name: \"info\"\
-          \n          help: \"Velero DBR with phase label (only when phase exists).\"\
-          \n          each:\n            type: Info\n            info:\n         \
-          \     labelsFromPath:\n                phase: [status, phase]\n    # ----\
-          \ VolumeSnapshotContent (cluster-scoped) ----\n    # With deletionPolicy=Delete,\
-          \ VSCs should not persist.\n    # Any existing VSC is an orphan from a stuck\
-          \ deletion.\n    # Signal: count > 0 = problem.\n    - groupVersionKind:\n\
-          \        group: snapshot.storage.k8s.io\n        version: v1\n        kind:\
-          \ VolumeSnapshotContent\n      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n\
-          \        vsc_name:\n          - metadata\n          - name\n      metrics:\n\
-          \        - name: \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
+          \     - name: \"spec_info\"\n          help: \"Static spec-derived info\
+          \ for a nodepool\"\n          each:\n            type: Info\n          \
+          \  info:\n                labelsFromPath:\n                  market_type:\
+          \ [spec, platform, aws, placement, marketType]\n    # ---- Velero Backup\
+          \ CRs ----\n    # Two metrics needed because newly enqueued backups have\
+          \ status: {}\n    # (no phase set yet), and KSM Info metrics are NOT emitted\
+          \ when the\n    # labelsFromPath path cannot resolve.\n    #\n    # \"created\"\
+          \ (Gauge): always emits for every Backup CR \u2192 gives total count.\n\
+          \    # \"info\" (Info): only emits when status.phase exists \u2192 gives\
+          \ count by phase.\n    # Enqueued backups = count(created) - count(info).\n\
+          \    - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: Backup\n      metricNamePrefix: velero_backup_cr\n      labelsFromPath:\n\
+          \        backup_name:\n          - metadata\n          - name\n        exported_namespace:\n\
+          \          - metadata\n          - namespace\n      metrics:\n        -\
+          \ name: \"created\"\n          help: \"Creation timestamp of Velero backup\
+          \ CR (always emitted).\"\n          each:\n            type: Gauge\n   \
+          \         gauge:\n              path: [metadata, creationTimestamp]\n  \
+          \      - name: \"info\"\n          help: \"Velero backup CR with phase label\
+          \ (only when phase exists).\"\n          each:\n            type: Info\n\
+          \            info:\n              labelsFromPath:\n                phase:\
+          \ [status, phase]\n    # ---- Velero DeleteBackupRequest CRs ----\n    #\
+          \ Same pattern as Backups: most DBRs have status: {} while enqueued,\n \
+          \   # only the one actively being processed has status.phase: InProgress.\n\
+          \    # \"created\" gives total count, \"info\" gives count by phase.\n \
+          \   - groupVersionKind:\n        group: velero.io\n        version: v1\n\
+          \        kind: DeleteBackupRequest\n      metricNamePrefix: velero_dbr_cr\n\
+          \      labelsFromPath:\n        dbr_name:\n          - metadata\n      \
+          \    - name\n        exported_namespace:\n          - metadata\n       \
+          \   - namespace\n      metrics:\n        - name: \"created\"\n         \
+          \ help: \"Creation timestamp of Velero DBR (always emitted).\"\n       \
+          \   each:\n            type: Gauge\n            gauge:\n              path:\
+          \ [metadata, creationTimestamp]\n        - name: \"info\"\n          help:\
+          \ \"Velero DBR with phase label (only when phase exists).\"\n          each:\n\
+          \            type: Info\n            info:\n              labelsFromPath:\n\
+          \                phase: [status, phase]\n    # ---- VolumeSnapshotContent\
+          \ (cluster-scoped) ----\n    # With deletionPolicy=Delete, VSCs should not\
+          \ persist.\n    # Any existing VSC is an orphan from a stuck deletion.\n\
+          \    # Signal: count > 0 = problem.\n    - groupVersionKind:\n        group:\
+          \ snapshot.storage.k8s.io\n        version: v1\n        kind: VolumeSnapshotContent\n\
+          \      metricNamePrefix: velero_vsc_cr\n      labelsFromPath:\n        vsc_name:\n\
+          \          - metadata\n          - name\n      metrics:\n        - name:\
+          \ \"created\"\n          help: \"Creation timestamp of VolumeSnapshotContent\
           \ (always emitted).\"\n          each:\n            type: Gauge\n      \
           \      gauge:\n              path: [metadata, creationTimestamp]\n    #\
           \ ---- VolumeSnapshot (namespace-scoped) ----\n    # Same as VSC: should\


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This PR adds a KSM metric to expose the market type of a nodepool.

For some nodepool related alert rules, we want to exclude the impact of spot instance nodepool. Unlike on-demand, spot instances may not always be able to provisioned, and this is an expected behavior.

Some alerting rules may have condition like:
```
hypershift_nodepools_available_replicas / hypershift_nodepools_size < 1
```
which checks if all nodes are available. We want to exclude the impact for the spot nodepools.

Having a KSM metric to tell whether a nodepool is spot, we can combine the metric to exclude spot nodepool.


### Which Jira/Github issue(s) this PR fixes?

https://redhat.atlassian.net/browse/ROSAENG-62424

### Special notes for your reviewer:

Tested in a staging MC environment.

If the `spec.platform.aws.placement.marketType` is not specified (default is on-demand), the metric will not appear.

If the `spec.platform.aws.placement.marketType` is spot, the metric will look like:
```
hypershift_nodepool_spec_info{_id="<internal-cluster-id>",cluster_name="siwu-uw2",customresource_group="hypershift.openshift.io",customresource_kind="NodePool",customresource_version="v1beta1",exported_namespace="xxxxxxx",market_type="Spot",nodepool_name="siwu-uw2-spot"} 1
```
Note the `market_type="Spot"`.



### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `market_type` label to NodePool state metrics, providing visibility into the AWS placement market type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->