### PR TITLE
ROSAENG-62424 have a dedicated provisioning_failure_notify for spot and send dedicated SL

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   fleetNotification:
     name: nodepool-provisioning-failure-spot
-    summary: Spot instance nodepool has not reached its desired size
+    summary: Spot instance machinepool has not reached its desired size
     notificationMessage: |-
-      One or more Spot instance nodepools in your ROSA cluster have not reached their desired size. This can prevent your workloads from running properly.
+      One or more Spot instance machinepools in your ROSA cluster have not reached their desired size. This can prevent your workloads from running properly.
 
       Common causes include:
       - Your maximum Spot price is below the current Spot price for the selected instance type

--- a/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
@@ -1,0 +1,22 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedFleetNotification
+metadata:
+  name: nodepool-provisioning-failure-spot
+  namespace: openshift-ocm-agent-operator
+spec:
+  fleetNotification:
+    name: nodepool-provisioning-failure-spot
+    summary: Spot instance nodepool has not reached its desired size
+    notificationMessage: |-
+      One or more Spot instance nodepools in your ROSA cluster has not reached its desired size. This can prevent your workloads from running properly.
+
+      Common causes include:
+      - Your maximum Spot price is below the current Spot price for the selected instance type
+      - There is not enough Spot capacity available for the requested instance type in the selected availability zone
+
+      For other common issues, please refer to: https://access.redhat.com/articles/7132524
+
+      If you need assistance, please open a support case.
+    resendWait: 24
+    severity: Warning
+    limitedSupport: false

--- a/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/nodepool-provisioning-failure-spot.yaml
@@ -8,7 +8,7 @@ spec:
     name: nodepool-provisioning-failure-spot
     summary: Spot instance nodepool has not reached its desired size
     notificationMessage: |-
-      One or more Spot instance nodepools in your ROSA cluster has not reached its desired size. This can prevent your workloads from running properly.
+      One or more Spot instance nodepools in your ROSA cluster have not reached their desired size. This can prevent your workloads from running properly.
 
       Common causes include:
       - Your maximum Spot price is below the current Spot price for the selected instance type

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
@@ -38,15 +38,53 @@ spec:
                 "^(.*?)-(.*?)-(.*?)-.*$"
               )
             )
+        - record: sre:nodepool:provisioning_failure_notify_spot
+          expr: |-
+            sum by (_id, cluster_name, exported_namespace, namespace) (
+              (
+                (
+                  (hypershift_nodepools_available_replicas / hypershift_nodepools_size < 1)
+                  and on (exported_namespace, name) label_replace(
+                    hypershift_nodepool_spec_info{market_type="Spot"},
+                    "name", "$1", "nodepool_name", "(.*)"
+                  )
+                  unless on (_id) (
+                    hypershift_nodepools_size == 0
+                    or
+                    hypershift_cluster_limited_support_enabled == 1
+                  )
+                )
+                unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+              )
+              unless on (exported_namespace) label_replace(
+                capi_machine_info{status_phase="Deleting"},
+                "exported_namespace",
+                "$1-$2-$3",
+                "exported_namespace",
+                "^(.*?)-(.*?)-(.*?)-.*$"
+              )
+            )
         - alert: NodepoolFailureNotification
           annotations:
-            description: "One or more nodepool for cluster {{ $labels._id }} has not reached its target size for more than 1 hour"
-            summary: "NodePool provisioning Failure"
+            description: "One or more on-demand nodepool for cluster {{ $labels._id }} has not reached its target size for more than 1 hour"
+            summary: "On-demand NodePool provisioning Failure"
           expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
           for: 60m
           labels:
             severity: critical
             send_managed_notification: "true"
             managed_notification_template: nodepool-provisioning-failure
+            cluster_id: "{{ $labels._id }}"
+            namespace: "{{ $labels.namespace }}"
+        - alert: SpotNodepoolFailureNotification
+          annotations:
+            description: "One or more spot instance nodepool for cluster {{ $labels._id }} has not reached its target size for more than 1 hour"
+            summary: "Spot NodePool provisioning Failure"
+          expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
+          for: 60m
+          labels:
+            severity: warning
+            send_managed_notification: "true"
+            managed_notification_template: nodepool-provisioning-failure-spot
             cluster_id: "{{ $labels._id }}"
             namespace: "{{ $labels.namespace }}"

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
@@ -18,6 +18,10 @@ spec:
               (
                 (
                   (hypershift_nodepools_available_replicas / hypershift_nodepools_size < 1)
+                  unless on (exported_namespace, name) label_replace(
+                    hypershift_nodepool_spec_info{market_type="Spot"},
+                    "name", "$1", "nodepool_name", "(.*)"
+                  )
                   unless on (_id) (
                     hypershift_nodepools_size == 0
                     or

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
@@ -66,7 +66,7 @@ spec:
             )
         - alert: NodepoolFailureNotification
           annotations:
-            description: "One or more on-demand nodepools for cluster {{ $labels._id }} have not reached its target size for more than 1 hour"
+            description: "One or more on-demand nodepools for cluster {{ $labels._id }} have not reached their target size for more than 1 hour"
             summary: "On-demand NodePool provisioning Failure"
           expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
           for: 60m
@@ -78,7 +78,7 @@ spec:
             namespace: "{{ $labels.namespace }}"
         - alert: SpotNodepoolFailureNotification
           annotations:
-            description: "One or more spot instance nodepools for cluster {{ $labels._id }} have not reached its target size for more than 1 hour"
+            description: "One or more spot instance nodepools for cluster {{ $labels._id }} have not reached their target size for more than 1 hour"
             summary: "Spot NodePool provisioning Failure"
           expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
           for: 60m

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-nodes-not-joining-nodepool.PrometheusRule.yaml
@@ -66,7 +66,7 @@ spec:
             )
         - alert: NodepoolFailureNotification
           annotations:
-            description: "One or more on-demand nodepool for cluster {{ $labels._id }} has not reached its target size for more than 1 hour"
+            description: "One or more on-demand nodepools for cluster {{ $labels._id }} have not reached its target size for more than 1 hour"
             summary: "On-demand NodePool provisioning Failure"
           expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
           for: 60m
@@ -78,7 +78,7 @@ spec:
             namespace: "{{ $labels.namespace }}"
         - alert: SpotNodepoolFailureNotification
           annotations:
-            description: "One or more spot instance nodepool for cluster {{ $labels._id }} has not reached its target size for more than 1 hour"
+            description: "One or more spot instance nodepools for cluster {{ $labels._id }} have not reached its target size for more than 1 hour"
             summary: "Spot NodePool provisioning Failure"
           expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace) (sre:nodepool:all_components_available == 1)) unless on (exported_namespace) sre:nodepool:invalid_payload_nodepool_provision_failure
           for: 60m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48579,7 +48579,7 @@ objects:
           - alert: NodepoolFailureNotification
             annotations:
               description: One or more on-demand nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48594,7 +48594,7 @@ objects:
           - alert: SpotNodepoolFailureNotification
             annotations:
               description: One or more spot instance nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32270,6 +32270,36 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: nodepool-provisioning-failure-spot
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: nodepool-provisioning-failure-spot
+          summary: Spot instance nodepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
+            has not reached its desired size. This can prevent your workloads from
+            running properly.
+
+
+            Common causes include:
+
+            - Your maximum Spot price is below the current Spot price for the selected
+            instance type
+
+            - There is not enough Spot capacity available for the requested instance
+            type in the selected availability zone
+
+
+            For other common issues, please refer to: https://access.redhat.com/articles/7132524
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48534,11 +48564,23 @@ objects:
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
+          - record: sre:nodepool:provisioning_failure_notify_spot
+            expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
+              \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
+              \ < 1)\n      and on (exported_namespace, name) label_replace(\n   \
+              \     hypershift_nodepool_spec_info{market_type=\"Spot\"},\n       \
+              \ \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
+              Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
+              exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more nodepool for cluster {{ $labels._id }} has
-                not reached its target size for more than 1 hour
-              summary: NodePool provisioning Failure
+              description: One or more on-demand nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
               sre:nodepool:invalid_payload_nodepool_provision_failure
@@ -48547,6 +48589,21 @@ objects:
               severity: critical
               send_managed_notification: 'true'
               managed_notification_template: nodepool-provisioning-failure
+              cluster_id: '{{ $labels._id }}'
+              namespace: '{{ $labels.namespace }}'
+          - alert: SpotNodepoolFailureNotification
+            annotations:
+              description: One or more spot instance nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: Spot NodePool provisioning Failure
+            expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
+              (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
+              sre:nodepool:invalid_payload_nodepool_provision_failure
+            for: 60m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: nodepool-provisioning-failure-spot
               cluster_id: '{{ $labels._id }}'
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32275,10 +32275,10 @@ objects:
       spec:
         fleetNotification:
           name: nodepool-provisioning-failure-spot
-          summary: Spot instance nodepool has not reached its desired size
-          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            have not reached their desired size. This can prevent your workloads from
-            running properly.
+          summary: Spot instance machinepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance machinepools in your ROSA
+            cluster have not reached their desired size. This can prevent your workloads
+            from running properly.
 
 
             Common causes include:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48525,9 +48525,12 @@ objects:
           - record: sre:nodepool:provisioning_failure_notify
             expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
               \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
-              \ < 1)\n      unless on (_id) (\n        hypershift_nodepools_size ==\
-              \ 0\n        or\n        hypershift_cluster_limited_support_enabled\
-              \ == 1\n      )\n    )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \ < 1)\n      unless on (exported_namespace, name) label_replace(\n\
+              \        hypershift_nodepool_spec_info{market_type=\"Spot\"},\n    \
+              \    \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32277,7 +32277,7 @@ objects:
           name: nodepool-provisioning-failure-spot
           summary: Spot instance nodepool has not reached its desired size
           notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            has not reached its desired size. This can prevent your workloads from
+            have not reached their desired size. This can prevent your workloads from
             running properly.
 
 
@@ -48578,8 +48578,8 @@ objects:
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more on-demand nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more on-demand nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48593,8 +48593,8 @@ objects:
               namespace: '{{ $labels.namespace }}'
           - alert: SpotNodepoolFailureNotification
             annotations:
-              description: One or more spot instance nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more spot instance nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48579,7 +48579,7 @@ objects:
           - alert: NodepoolFailureNotification
             annotations:
               description: One or more on-demand nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48594,7 +48594,7 @@ objects:
           - alert: SpotNodepoolFailureNotification
             annotations:
               description: One or more spot instance nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32270,6 +32270,36 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: nodepool-provisioning-failure-spot
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: nodepool-provisioning-failure-spot
+          summary: Spot instance nodepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
+            has not reached its desired size. This can prevent your workloads from
+            running properly.
+
+
+            Common causes include:
+
+            - Your maximum Spot price is below the current Spot price for the selected
+            instance type
+
+            - There is not enough Spot capacity available for the requested instance
+            type in the selected availability zone
+
+
+            For other common issues, please refer to: https://access.redhat.com/articles/7132524
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48534,11 +48564,23 @@ objects:
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
+          - record: sre:nodepool:provisioning_failure_notify_spot
+            expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
+              \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
+              \ < 1)\n      and on (exported_namespace, name) label_replace(\n   \
+              \     hypershift_nodepool_spec_info{market_type=\"Spot\"},\n       \
+              \ \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
+              Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
+              exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more nodepool for cluster {{ $labels._id }} has
-                not reached its target size for more than 1 hour
-              summary: NodePool provisioning Failure
+              description: One or more on-demand nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
               sre:nodepool:invalid_payload_nodepool_provision_failure
@@ -48547,6 +48589,21 @@ objects:
               severity: critical
               send_managed_notification: 'true'
               managed_notification_template: nodepool-provisioning-failure
+              cluster_id: '{{ $labels._id }}'
+              namespace: '{{ $labels.namespace }}'
+          - alert: SpotNodepoolFailureNotification
+            annotations:
+              description: One or more spot instance nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: Spot NodePool provisioning Failure
+            expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
+              (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
+              sre:nodepool:invalid_payload_nodepool_provision_failure
+            for: 60m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: nodepool-provisioning-failure-spot
               cluster_id: '{{ $labels._id }}'
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32275,10 +32275,10 @@ objects:
       spec:
         fleetNotification:
           name: nodepool-provisioning-failure-spot
-          summary: Spot instance nodepool has not reached its desired size
-          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            have not reached their desired size. This can prevent your workloads from
-            running properly.
+          summary: Spot instance machinepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance machinepools in your ROSA
+            cluster have not reached their desired size. This can prevent your workloads
+            from running properly.
 
 
             Common causes include:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48525,9 +48525,12 @@ objects:
           - record: sre:nodepool:provisioning_failure_notify
             expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
               \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
-              \ < 1)\n      unless on (_id) (\n        hypershift_nodepools_size ==\
-              \ 0\n        or\n        hypershift_cluster_limited_support_enabled\
-              \ == 1\n      )\n    )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \ < 1)\n      unless on (exported_namespace, name) label_replace(\n\
+              \        hypershift_nodepool_spec_info{market_type=\"Spot\"},\n    \
+              \    \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32277,7 +32277,7 @@ objects:
           name: nodepool-provisioning-failure-spot
           summary: Spot instance nodepool has not reached its desired size
           notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            has not reached its desired size. This can prevent your workloads from
+            have not reached their desired size. This can prevent your workloads from
             running properly.
 
 
@@ -48578,8 +48578,8 @@ objects:
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more on-demand nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more on-demand nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48593,8 +48593,8 @@ objects:
               namespace: '{{ $labels.namespace }}'
           - alert: SpotNodepoolFailureNotification
             annotations:
-              description: One or more spot instance nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more spot instance nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48579,7 +48579,7 @@ objects:
           - alert: NodepoolFailureNotification
             annotations:
               description: One or more on-demand nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48594,7 +48594,7 @@ objects:
           - alert: SpotNodepoolFailureNotification
             annotations:
               description: One or more spot instance nodepools for cluster {{ $labels._id
-                }} have not reached its target size for more than 1 hour
+                }} have not reached their target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32270,6 +32270,36 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: nodepool-provisioning-failure-spot
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: nodepool-provisioning-failure-spot
+          summary: Spot instance nodepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
+            has not reached its desired size. This can prevent your workloads from
+            running properly.
+
+
+            Common causes include:
+
+            - Your maximum Spot price is below the current Spot price for the selected
+            instance type
+
+            - There is not enough Spot capacity available for the requested instance
+            type in the selected availability zone
+
+
+            For other common issues, please refer to: https://access.redhat.com/articles/7132524
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48534,11 +48564,23 @@ objects:
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
+          - record: sre:nodepool:provisioning_failure_notify_spot
+            expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
+              \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
+              \ < 1)\n      and on (exported_namespace, name) label_replace(\n   \
+              \     hypershift_nodepool_spec_info{market_type=\"Spot\"},\n       \
+              \ \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
+              Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
+              exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more nodepool for cluster {{ $labels._id }} has
-                not reached its target size for more than 1 hour
-              summary: NodePool provisioning Failure
+              description: One or more on-demand nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
               sre:nodepool:invalid_payload_nodepool_provision_failure
@@ -48547,6 +48589,21 @@ objects:
               severity: critical
               send_managed_notification: 'true'
               managed_notification_template: nodepool-provisioning-failure
+              cluster_id: '{{ $labels._id }}'
+              namespace: '{{ $labels.namespace }}'
+          - alert: SpotNodepoolFailureNotification
+            annotations:
+              description: One or more spot instance nodepool for cluster {{ $labels._id
+                }} has not reached its target size for more than 1 hour
+              summary: Spot NodePool provisioning Failure
+            expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
+              (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
+              sre:nodepool:invalid_payload_nodepool_provision_failure
+            for: 60m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: nodepool-provisioning-failure-spot
               cluster_id: '{{ $labels._id }}'
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32275,10 +32275,10 @@ objects:
       spec:
         fleetNotification:
           name: nodepool-provisioning-failure-spot
-          summary: Spot instance nodepool has not reached its desired size
-          notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            have not reached their desired size. This can prevent your workloads from
-            running properly.
+          summary: Spot instance machinepool has not reached its desired size
+          notificationMessage: 'One or more Spot instance machinepools in your ROSA
+            cluster have not reached their desired size. This can prevent your workloads
+            from running properly.
 
 
             Common causes include:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48525,9 +48525,12 @@ objects:
           - record: sre:nodepool:provisioning_failure_notify
             expr: "sum by (_id, cluster_name, exported_namespace, namespace) (\n \
               \ (\n    (\n      (hypershift_nodepools_available_replicas / hypershift_nodepools_size\
-              \ < 1)\n      unless on (_id) (\n        hypershift_nodepools_size ==\
-              \ 0\n        or\n        hypershift_cluster_limited_support_enabled\
-              \ == 1\n      )\n    )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
+              \ < 1)\n      unless on (exported_namespace, name) label_replace(\n\
+              \        hypershift_nodepool_spec_info{market_type=\"Spot\"},\n    \
+              \    \"name\", \"$1\", \"nodepool_name\", \"(.*)\"\n      )\n      unless\
+              \ on (_id) (\n        hypershift_nodepools_size == 0\n        or\n \
+              \       hypershift_cluster_limited_support_enabled == 1\n      )\n \
+              \   )\n    unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])\n\
               \  )\n  unless on (exported_namespace) label_replace(\n    capi_machine_info{status_phase=\"\
               Deleting\"},\n    \"exported_namespace\",\n    \"$1-$2-$3\",\n    \"\
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32277,7 +32277,7 @@ objects:
           name: nodepool-provisioning-failure-spot
           summary: Spot instance nodepool has not reached its desired size
           notificationMessage: 'One or more Spot instance nodepools in your ROSA cluster
-            has not reached its desired size. This can prevent your workloads from
+            have not reached their desired size. This can prevent your workloads from
             running properly.
 
 
@@ -48578,8 +48578,8 @@ objects:
               exported_namespace\",\n    \"^(.*?)-(.*?)-(.*?)-.*$\"\n  )\n)"
           - alert: NodepoolFailureNotification
             annotations:
-              description: One or more on-demand nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more on-demand nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: On-demand NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)
@@ -48593,8 +48593,8 @@ objects:
               namespace: '{{ $labels.namespace }}'
           - alert: SpotNodepoolFailureNotification
             annotations:
-              description: One or more spot instance nodepool for cluster {{ $labels._id
-                }} has not reached its target size for more than 1 hour
+              description: One or more spot instance nodepools for cluster {{ $labels._id
+                }} have not reached its target size for more than 1 hour
               summary: Spot NodePool provisioning Failure
             expr: (sre:nodepool:provisioning_failure_notify_spot and on (exported_namespace)
               (sre:nodepool:all_components_available == 1)) unless on (exported_namespace)


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR is to exclude the spot nodepool in the `provisioning_failure_notify` recording rule and make it for on-demand nodepool.

Originally, the recording rule assumes the nodepool are all on-demand, so nodes should all be able to provision, otherwise there could be a problem.

But for spot instances, it is likely not to be able to provision due to pricing or AWS capacity, which is expected. We don't want to trigger alerts if the nodepool is running spot.

For the spot instance nodepool, we add `provisioning_failure_notify_spot` delicately, and add a SL template for spot nodepool. 

### Which Jira/Github issue(s) this PR fixes?

https://redhat.atlassian.net/browse/ROSAENG-62424

### Special notes for your reviewer:

Validated, steps:
- Create a HCP cluster in staging.
- Create a nodepool manually in the HC namespace in the corresponding MC.
- Go to Grafana and check the metrics.
- Because I can provision the spot nodepool smoothly, I changed the PromQL from `<` to `==` to see how the recording rule behave.
```
(hypershift_nodepools_available_replicas / hypershift_nodepools_size == 1)
```
(keep the other conditions same as this PR)
- Without the change in this PR, I can see all nodepools including spot.
- With the change in this PR, the spot nodepool is excluded, the other nodepool / other clusters remain the same.


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added dedicated monitoring and warning notifications for Spot node pool provisioning failures.
- Added Spot-specific notification content, resend intervals, and limited-support status.

## Bug Fixes

- Improved provisioning failure monitoring by separating Spot and on-demand node pools.
- Clarified on-demand alerts and reduced misleading notifications by ensuring each node pool type receives relevant alerts.
- Updated notification details to provide clearer, more actionable provisioning-failure information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->