### PR TITLE
[FedRAMP] Make CgaoInactiveHeartbeat less sensitive in the case of gaps in series

### DIFF
--- a/deploy/sre-prometheus/fedramp/hive-prod/100-cgao-inactive-heartbeatmonitor.yaml
+++ b/deploy/sre-prometheus/fedramp/hive-prod/100-cgao-inactive-heartbeatmonitor.yaml
@@ -10,6 +10,7 @@ spec:
     - alert: CgaoInactiveHeartbeat
       expr: cgao_heartbeat_inactive > 0
       for: 120m
+      keep_firing_for: 30m
       labels:
         severity: critical
         namespace: "{{ $labels.namespace }}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -46925,6 +46925,7 @@ objects:
           - alert: CgaoInactiveHeartbeat
             expr: cgao_heartbeat_inactive > 0
             for: 120m
+            keep_firing_for: 30m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -46925,6 +46925,7 @@ objects:
           - alert: CgaoInactiveHeartbeat
             expr: cgao_heartbeat_inactive > 0
             for: 120m
+            keep_firing_for: 30m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -46925,6 +46925,7 @@ objects:
           - alert: CgaoInactiveHeartbeat
             expr: cgao_heartbeat_inactive > 0
             for: 120m
+            keep_firing_for: 30m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Adds `keep_firing_for: 30m` to FedRAMP alert `CgaoInactiveHeartbeat`

In FedRAMP, we've had instances where a pod restart creates a minor gap in the metric series, AM then clears the alert and it re-fires, creating noise.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Alerts for inactive heartbeats now remain active for an additional 30 minutes after the triggering condition clears, improving alert continuity and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->