### PR TITLE
ROSAENG-4015: Update ethtool exporter images from 4.16 to 4.21

### DIFF
--- a/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
+++ b/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
@@ -50,9 +50,9 @@ spec:
             - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
             - --runtime.gomaxprocs=0
           name: ethtool-exporter
-          # Taken from PROD 4.16.42 MCs currently using: @sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+          # Taken from PROD 4.21.16 MCs CMO node-exporter daemonset (verified consistent across all 13 MCs)
           # Can also use image: prom/node-exporter
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
           command:
             - /bin/sh
             - -c
@@ -107,8 +107,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-          # Taken from PROD 4.16.42 MCs currently using: sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
+          # Taken from PROD 4.21.16 MCs CMO node-exporter daemonset (verified consistent across all 13 MCs)
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:731316e9d5192651ed8706d614a00dc3cb02dc2c42a208ee2c9ba8426509d329
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:
@@ -149,8 +149,8 @@ spec:
           env:
             - name: TMPDIR
               value: /tmp
-          # Taken from PROD 4.16.42 MCs currently using: sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cdd
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+          # Taken from PROD 4.21.16 MCs CMO node-exporter daemonset (verified consistent across all 13 MCs)
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
           imagePullPolicy: IfNotPresent
           name: init-textfile
           resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -49110,7 +49110,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               command:
               - /bin/sh
               - -c
@@ -49162,7 +49162,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:731316e9d5192651ed8706d614a00dc3cb02dc2c42a208ee2c9ba8426509d329
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -49204,7 +49204,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -49110,7 +49110,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               command:
               - /bin/sh
               - -c
@@ -49162,7 +49162,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:731316e9d5192651ed8706d614a00dc3cb02dc2c42a208ee2c9ba8426509d329
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -49204,7 +49204,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -49110,7 +49110,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               command:
               - /bin/sh
               - -c
@@ -49162,7 +49162,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:731316e9d5192651ed8706d614a00dc3cb02dc2c42a208ee2c9ba8426509d329
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -49204,7 +49204,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d6a42d8f53b8447c08deb000d34600ebd1974c66575b08e4f45dc575f8484d
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:


### PR DESCRIPTION
## Summary
- Update supplemental ethtool node-exporter and kube-rbac-proxy images to match CMO node-exporter
  images running on 4.21.16 MCs
- The current stop-gap deployment is functioning correctly — this update is proactive maintenance
  to keep the images aligned with the CMO node-exporter images running on the MCs
- All 13 production MCs verified to be running identical images on OCP 4.21.16
- Image updates:
  - node-exporter: `sha256:85765701...` -> `sha256:f4d6a42d...`
  - kube-rbac-proxy: `sha256:82f5ad5a...` -> `sha256:731316e9...`

## Note: Draft Status
This PR is marked as draft pending manual validation. The updated images need to be
manually applied and verified on an integration or staging MC before this PR is ready
for merge. Validation should confirm:
- DaemonSet pods start and run without errors
- Scrape targets are healthy
- Only the expected `*_allowance_exceeded` metrics are collected
- No interference with CMO / openshift-monitoring
- Pod resource consumption is reasonable

Once validated, this PR can be marked ready for review and promoted through the
standard integration -> staging -> production pipeline.

## Note: Upstream CMO ethtool collector support
[RFE-7342](https://redhat.atlassian.net/browse/RFE-7342) (Enable the ethtool collector
for OpenShift Monitoring Node Exporter) is still in Refinement. The CMO configuration
support has landed upstream via [CMO#2779](https://github.com/openshift/cluster-monitoring-operator/pull/2779),
but only for OCP 4.22+. The MCs are currently running 4.21.16 and are not yet on a
version that supports the native CMO ethtool collector. This supplemental node-exporter
remains necessary until the MCs upgrade to 4.22, at which point [ROSAENG-1211](https://redhat.atlassian.net/browse/ROSAENG-1211)
tracks removing this stop-gap and configuring the CMO-native collector instead.

## Related
- Jira: [ROSAENG-4015](https://redhat.atlassian.net/browse/ROSAENG-4015)
- Original deployment: [managed-cluster-config#2495](https://github.com/openshift/managed-cluster-config/pull/2495)
- Upstream RFE: [RFE-7342](https://redhat.atlassian.net/browse/RFE-7342) (status: Refinement)
- Deprecation tracker: [ROSAENG-1211](https://redhat.atlassian.net/browse/ROSAENG-1211)

🤖 Generated with [Claude Code](https://claude.com/claude-code)