### PR TITLE
[ROSA-1346] Fix OADP visibility in sre:operators:succeeded recording rule

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -20,7 +20,16 @@ spec:
               sum by (exported_namespace, name, version, channel, package) (
                   label_replace(csv_succeeded, "name", "$1", "name", "([^.]+).*")
                 ^ on (name) group_left (channel, package)
-                  max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
+                  (
+                    max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
+                    or
+                    # OADP: subscription name (redhat-oadp-operator) differs from CSV name (oadp-operator),
+                    # so normalize the subscription name to match the CSV prefix for the join.
+                    label_replace(
+                      max by (channel, package) (subscription_sync_total{name="redhat-oadp-operator"}),
+                      "name", "oadp-operator", "name", ".*"
+                    )
+                  )
               )
           record:
             sre:operators:succeeded:olm

--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -11,62 +11,60 @@ spec:
     - name: sre-operators.rules
       rules:
         # OLM-based operators
+        # csv_succeeded has a value of 1 or 0
+        # subscription_sync_total is an integer with value >0
+        # joining them with the operator ^ returns a value of 1 or 0
         - expr: |
-            # csv_succeeded has a value of 1 or 0
-            # subscription_sync_total is an integer with value >0
-            # joining them with the operator ^ returns a value of 1 or 0
-              label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
+            label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
             * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, name, version, channel, package) (
-                  label_replace(csv_succeeded, "name", "$1", "name", "([^.]+).*")
-                ^ on (name) group_left (channel, package)
-                  (
-                    max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
-                    or
-                    # OADP: subscription name (redhat-oadp-operator) differs from CSV name (oadp-operator),
-                    # so normalize the subscription name to match the CSV prefix for the join.
-                    label_replace(
-                      max by (channel, package) (subscription_sync_total{name="redhat-oadp-operator"}),
-                      "name", "oadp-operator", "name", ".*"
-                    )
+            sum by (exported_namespace, name, version, channel, package) (
+                label_replace(csv_succeeded, "name", "$1", "name", "([^.]+).*")
+              ^ on (name) group_left (channel, package)
+                (
+                  max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
+                  or
+                  label_replace(
+                    max by (channel, package) (subscription_sync_total{name="redhat-oadp-operator"}),
+                    "name", "oadp-operator", "name", ".*"
                   )
-              )
+                )
+            )
           record:
             sre:operators:succeeded:olm
         # PKO-based operators
         # Uses package_operator_package_availability metric exported by package-operator itself
+        # package_operator_package_availability=1 means operator is successfully deployed
+        # We construct labels to match OLM format: exported_namespace, name, version, channel, package
         - expr: |
-            # package_operator_package_availability=1 means operator is successfully deployed
-            # We construct labels to match OLM format: exported_namespace, name, version, channel, package
-              label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
+            label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
             * on () group_right (_id, cluster_version, provider)
-              max by (exported_namespace, name, version, channel, package) (
+            max by (exported_namespace, name, version, channel, package) (
+              label_replace(
                 label_replace(
                   label_replace(
                     label_replace(
                       label_replace(
-                        label_replace(
-                          (package_operator_package_availability{pko_name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"} == 1),
-                          "exported_namespace", "openshift-$1", "pko_name", "^(?:openshift-)?(.*)$"
-                        ),
-                        "version", "$1", "image", "^[^@]+:([^@]+)(?:@.+)?$"
+                        (package_operator_package_availability{pko_name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"} == 1),
+                        "exported_namespace", "openshift-$1", "pko_name", "^(?:openshift-)?(.*)$"
                       ),
-                      "channel", "pko", "", ""
+                      "version", "$1", "image", "^[^@]+:([^@]+)(?:@.+)?$"
                     ),
-                    "package", "$1", "pko_name", "(.*)$"
+                    "channel", "pko", "", ""
                   ),
-                  "name", "$1", "pko_name", "(.*)$"
-                )
+                  "package", "$1", "pko_name", "(.*)$"
+                ),
+                "name", "$1", "pko_name", "(.*)$"
               )
+            )
           record:
             sre:operators:succeeded:pko
         # evaulate raw metric success on success of either olm or pko
-        - expr: |
-            sre:operators:succeeded:olm or sre:operators:succeeded:pko
+        - expr: sre:operators:succeeded:olm or sre:operators:succeeded:pko
           record:
             sre:operators:succeeded:raw
+        # making sure that operators installed in user workload namespaces are ignored
+        # in case the same operator is installed in an openshift namespace
         - expr: |
-            # making sure that operators installed in user workload namespaces are ignored in case the same operator is installed in an openshift namespace
             sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
             or on(_id, name)
             sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}

--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -11,7 +11,7 @@ spec:
     - name: sre-operators.rules
       rules:
         # OLM-based operators
-        - expr:
+        - expr: |
             # csv_succeeded has a value of 1 or 0
             # subscription_sync_total is an integer with value >0
             # joining them with the operator ^ returns a value of 1 or 0
@@ -35,7 +35,7 @@ spec:
             sre:operators:succeeded:olm
         # PKO-based operators
         # Uses package_operator_package_availability metric exported by package-operator itself
-        - expr:
+        - expr: |
             # package_operator_package_availability=1 means operator is successfully deployed
             # We construct labels to match OLM format: exported_namespace, name, version, channel, package
               label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
@@ -61,11 +61,11 @@ spec:
           record:
             sre:operators:succeeded:pko
         # evaulate raw metric success on success of either olm or pko
-        - expr:
+        - expr: |
             sre:operators:succeeded:olm or sre:operators:succeeded:pko
           record:
             sre:operators:succeeded:raw
-        - expr:
+        - expr: |
             # making sure that operators installed in user workload namespaces are ignored in case the same operator is installed in an openshift namespace
             sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
             or on(_id, name)

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -46349,26 +46349,39 @@ objects:
         groups:
         - name: sre-operators.rules
           rules:
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
-              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
-              )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nsum by (exported_namespace, name, version, channel, package)\
+              \ (\n    label_replace(csv_succeeded, \"name\", \"$1\", \"name\", \"\
+              ([^.]+).*\")\n  ^ on (name) group_left (channel, package)\n    (\n \
+              \     max by (name, channel, package) (subscription_sync_total{name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              })\n      or\n      label_replace(\n        max by (channel, package)\
+              \ (subscription_sync_total{name=\"redhat-oadp-operator\"}),\n      \
+              \  \"name\", \"oadp-operator\", \"name\", \".*\"\n      )\n    )\n)\n"
             record: sre:operators:succeeded:olm
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              max by (exported_namespace, name, version, channel, package) ( label_replace(
-              label_replace( label_replace( label_replace( label_replace( (package_operator_package_availability{pko_name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
-              == 1), "exported_namespace", "openshift-$1", "pko_name", "^(?:openshift-)?(.*)$"
-              ), "version", "$1", "image", "^[^@]+:([^@]+)(?:@.+)?$" ), "channel",
-              "pko", "", "" ), "package", "$1", "pko_name", "(.*)$" ), "name", "$1",
-              "pko_name", "(.*)$" ) )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nmax by (exported_namespace, name, version, channel, package)\
+              \ (\n  label_replace(\n    label_replace(\n      label_replace(\n  \
+              \      label_replace(\n          label_replace(\n            (package_operator_package_availability{pko_name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              } == 1),\n            \"exported_namespace\", \"openshift-$1\", \"pko_name\"\
+              , \"^(?:openshift-)?(.*)$\"\n          ),\n          \"version\", \"\
+              $1\", \"image\", \"^[^@]+:([^@]+)(?:@.+)?$\"\n        ),\n        \"\
+              channel\", \"pko\", \"\", \"\"\n      ),\n      \"package\", \"$1\"\
+              , \"pko_name\", \"(.*)$\"\n    ),\n    \"name\", \"$1\", \"pko_name\"\
+              , \"(.*)$\"\n  )\n)\n"
             record: sre:operators:succeeded:pko
           - expr: sre:operators:succeeded:olm or sre:operators:succeeded:pko
             record: sre:operators:succeeded:raw
-          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
-              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+          - expr: 'sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+
+              or on(_id, name)
+
+              sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+
+              '
             record: sre:operators:succeeded
           - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
               , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -46349,26 +46349,39 @@ objects:
         groups:
         - name: sre-operators.rules
           rules:
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
-              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
-              )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nsum by (exported_namespace, name, version, channel, package)\
+              \ (\n    label_replace(csv_succeeded, \"name\", \"$1\", \"name\", \"\
+              ([^.]+).*\")\n  ^ on (name) group_left (channel, package)\n    (\n \
+              \     max by (name, channel, package) (subscription_sync_total{name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              })\n      or\n      label_replace(\n        max by (channel, package)\
+              \ (subscription_sync_total{name=\"redhat-oadp-operator\"}),\n      \
+              \  \"name\", \"oadp-operator\", \"name\", \".*\"\n      )\n    )\n)\n"
             record: sre:operators:succeeded:olm
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              max by (exported_namespace, name, version, channel, package) ( label_replace(
-              label_replace( label_replace( label_replace( label_replace( (package_operator_package_availability{pko_name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
-              == 1), "exported_namespace", "openshift-$1", "pko_name", "^(?:openshift-)?(.*)$"
-              ), "version", "$1", "image", "^[^@]+:([^@]+)(?:@.+)?$" ), "channel",
-              "pko", "", "" ), "package", "$1", "pko_name", "(.*)$" ), "name", "$1",
-              "pko_name", "(.*)$" ) )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nmax by (exported_namespace, name, version, channel, package)\
+              \ (\n  label_replace(\n    label_replace(\n      label_replace(\n  \
+              \      label_replace(\n          label_replace(\n            (package_operator_package_availability{pko_name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              } == 1),\n            \"exported_namespace\", \"openshift-$1\", \"pko_name\"\
+              , \"^(?:openshift-)?(.*)$\"\n          ),\n          \"version\", \"\
+              $1\", \"image\", \"^[^@]+:([^@]+)(?:@.+)?$\"\n        ),\n        \"\
+              channel\", \"pko\", \"\", \"\"\n      ),\n      \"package\", \"$1\"\
+              , \"pko_name\", \"(.*)$\"\n    ),\n    \"name\", \"$1\", \"pko_name\"\
+              , \"(.*)$\"\n  )\n)\n"
             record: sre:operators:succeeded:pko
           - expr: sre:operators:succeeded:olm or sre:operators:succeeded:pko
             record: sre:operators:succeeded:raw
-          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
-              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+          - expr: 'sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+
+              or on(_id, name)
+
+              sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+
+              '
             record: sre:operators:succeeded
           - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
               , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -46349,26 +46349,39 @@ objects:
         groups:
         - name: sre-operators.rules
           rules:
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
-              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
-              )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nsum by (exported_namespace, name, version, channel, package)\
+              \ (\n    label_replace(csv_succeeded, \"name\", \"$1\", \"name\", \"\
+              ([^.]+).*\")\n  ^ on (name) group_left (channel, package)\n    (\n \
+              \     max by (name, channel, package) (subscription_sync_total{name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              })\n      or\n      label_replace(\n        max by (channel, package)\
+              \ (subscription_sync_total{name=\"redhat-oadp-operator\"}),\n      \
+              \  \"name\", \"oadp-operator\", \"name\", \".*\"\n      )\n    )\n)\n"
             record: sre:operators:succeeded:olm
-          - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
-              "version", ".*") * on () group_right (_id, cluster_version, provider)
-              max by (exported_namespace, name, version, channel, package) ( label_replace(
-              label_replace( label_replace( label_replace( label_replace( (package_operator_package_availability{pko_name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
-              == 1), "exported_namespace", "openshift-$1", "pko_name", "^(?:openshift-)?(.*)$"
-              ), "version", "$1", "image", "^[^@]+:([^@]+)(?:@.+)?$" ), "channel",
-              "pko", "", "" ), "package", "$1", "pko_name", "(.*)$" ), "name", "$1",
-              "pko_name", "(.*)$" ) )
+          - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
+              , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\
+              \ provider)\nmax by (exported_namespace, name, version, channel, package)\
+              \ (\n  label_replace(\n    label_replace(\n      label_replace(\n  \
+              \      label_replace(\n          label_replace(\n            (package_operator_package_availability{pko_name=~\"\
+              addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator\"\
+              } == 1),\n            \"exported_namespace\", \"openshift-$1\", \"pko_name\"\
+              , \"^(?:openshift-)?(.*)$\"\n          ),\n          \"version\", \"\
+              $1\", \"image\", \"^[^@]+:([^@]+)(?:@.+)?$\"\n        ),\n        \"\
+              channel\", \"pko\", \"\", \"\"\n      ),\n      \"package\", \"$1\"\
+              , \"pko_name\", \"(.*)$\"\n    ),\n    \"name\", \"$1\", \"pko_name\"\
+              , \"(.*)$\"\n  )\n)\n"
             record: sre:operators:succeeded:pko
           - expr: sre:operators:succeeded:olm or sre:operators:succeeded:pko
             record: sre:operators:succeeded:raw
-          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
-              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+          - expr: 'sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+
+              or on(_id, name)
+
+              sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+
+              '
             record: sre:operators:succeeded
           - expr: "label_replace(sre:telemetry:managed_labels, \"cluster_version\"\
               , \"$0\", \"version\", \".*\")\n* on () group_right (_id, cluster_version,\


### PR DESCRIPTION
OADP's OLM subscription name (redhat-oadp-operator) does not match its CSV name prefix (oadp-operator), causing the join in sre:operators:succeeded:olm to silently drop all OADP data. Add a label_replace union on the subscription side to normalize redhat-oadp-operator -> oadp-operator before the join.

After this change, OADP clusters are queryable via:
  sre:operators:succeeded{package="redhat-oadp-operator"}

Verified on staging cluster cgong-mvo-oadp-test.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OADP operator monitoring by correctly matching its subscription data with available metrics.
  * Preserved existing subscription matching behavior for all other operators.
  * Improved the reliability and readability of Prometheus recording rules used for OLM, PKO, and raw-success monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->