### PR TITLE
Add OCP 5.0 Karpenter STS credentials policy

### DIFF
--- a/resources/sts/5.0/openshift_karpenter_cloud_credentials_policy.json
+++ b/resources/sts/5.0/openshift_karpenter_cloud_credentials_policy.json
@@ -1,0 +1,61 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate",
+                "ec2:TerminateInstances",
+                "ec2:DeleteLaunchTemplate",
+                "ec2:CreateTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeCapacityReservations",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypeOfferings",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:TagInstanceProfile",
+                "iam:GetInstanceProfile",
+                "iam:ListInstanceProfiles",
+                "iam:PassRole"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "pricing:GetProducts"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
OpenShift 5.0.0-ec.5 introduces a new Karpenter CredentialsRequest. Add the corresponding managed-cluster-config STS policy so gap analysis CHECK 1 from GAP Analysis Job passes for the 4.22 -> 5.0 upgrade path.

### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

- Generated/validated fix files from the 5.0 Prow failure
- Found the real gap: new Karpenter CredentialsRequest — stock autofix only updates existing files, so it missed this
- Added resources/sts/5.0/openshift_karpenter_cloud_credentials_policy.json

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
Assisted by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions enabling OpenShift Karpenter to manage EC2 capacity, launch templates, instance profiles, and related tags.
  * Added access to required EC2 resource details, SSM parameters, and AWS pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->