### PR TITLE
Remove obsolete CAPA STS permissions for OCP 5.0

### DIFF
--- a/resources/sts/5.0/openshift_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/5.0/openshift_capa_controller_manager_credentials_policy.json
@@ -27,11 +27,9 @@
         "ec2:DeleteTags",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAddresses",
-        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
-        "ec2:DescribeInternetGateways",
         "ec2:DescribeLaunchTemplateVersions",
         "ec2:DescribeLaunchTemplates",
         "ec2:DescribeNatGateways",
@@ -58,20 +56,6 @@
       ],
       "Resource": [
         "*"
-      ],
-      "Effect": "Allow"
-    },
-    {
-      "Condition": {
-        "StringLike": {
-          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
-        }
-      },
-      "Action": [
-        "iam:CreateServiceLinkedRole"
-      ],
-      "Resource": [
-        "arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
       ],
       "Effect": "Allow"
     },


### PR DESCRIPTION
Drop ec2:DescribeAvailabilityZones, ec2:DescribeInternetGateways, and iam:CreateServiceLinkedRole from the 5.0 CAPA policy to match the OCP 5.0.0-ec.5 CredentialsRequest change.

### What type of PR is this?
_(cleanup)_

### What this PR does / why we need it?
Removed from resources/sts/5.0/openshift_capa_controller_manager_credentials_policy.json:
ec2:DescribeAvailabilityZones
ec2:DescribeInternetGateways
iam:CreateServiceLinkedRole

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced cloud permissions by removing unnecessary availability zone and internet gateway read access.
  * Removed permission to create the Elastic Load Balancing service-linked IAM role.
  * Preserved required role-passing permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->