### PR TITLE
ROSAENG-4043: Promote per-node infra resize alerts to paging

### DIFF
--- a/deploy/sre-prometheus-per-node-infra/100-infra-per-node-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus-per-node-infra/100-infra-per-node-resizing.PrometheusRule.yaml
@@ -76,7 +76,7 @@ spec:
           count(cluster:nodes_roles{label_node_role_kubernetes_io="infra"}) - 1
         for: 45m
         labels:
-          severity: warning
+          severity: high
           namespace: openshift-monitoring
         annotations:
           summary: "Infra node above 90% CPU for 45 minutes"
@@ -90,7 +90,7 @@ spec:
           count(cluster:nodes_roles{label_node_role_kubernetes_io="infra"}) - 1
         for: 30m
         labels:
-          severity: warning
+          severity: high
           namespace: openshift-monitoring
         annotations:
           summary: "Infra node above 90% memory for 30 minutes"

--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -8,130 +8,28 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
-  - name: sre-infra-resource-consumption-recording.rules
-    rules:
-    ## Expression Explanation:
-    ## Average of value of
-    ## the Average (per node) rate of change of CPU time spent in non-idle modes, totalled by CPU, looking back across the past 1h,
-    ## "*" applies a label replace to limit output to infra nodes
-    ## Greater than (>) is the threshold
-    ## Count of the infra nodes - 1, divided by the total infra nodes gives the max percent CPU utilization free required to handle a full node failure, as a decimal value: 0.%%
-    ## Scalar converts the percent value from a vector to allow comparison with the rate vector
-      - expr: ( 
-                avg (
-                  avg by (instance) (
-                    sum by (cpu, instance) (
-                      rate(
-                        node_cpu_seconds_total{mode!="idle"}[1h]
-                      )
-                    )
-                  )
-                  *
-                  on (instance) (
-                    label_replace (
-                      kube_node_role{role ="infra"}, "instance", "$1", "node", "(.*)"
-                    )
-                  )
-                )
-                >
-                (
-                  scalar (
-                    (
-                      count (
-                        cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
-                      )
-                      - 1
-                    )
-                    /
-                    count (
-                      cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
-                    )
-                  )
-                )
-              )
-        record: sre:node_infra:excessive_consumption_cpu
-      ## Expression Explanation: 
-      ## 1, minus the total amount of free memory divided by the total amount of memory for the infra node type, gives us the percent used memory as a decimal value: 0.%%
-      ## Greater than (>) is the threshold
-      ## Count of the infra nodes - 1, divided by the total infra nodes gives the max percent memory utilization free required to handle a full node failure, as a decimal value: 0.%%
-      ## Scalar converts the percent value from a vector to allow comparison with the rate vector
-      - expr: ( 1 -
-                sum (
-                    node_memory_MemFree_bytes +
-                    node_memory_Buffers_bytes +
-                    node_memory_Cached_bytes
-                    AND on (instance) label_replace(
-                        kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"
-                    )
-                ) 
-                / 
-                sum (
-                    node_memory_MemTotal_bytes
-                    AND on (instance) label_replace(
-                        kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"
-                    )
-                )
-            ) 
-            > 
-            (
-              scalar (
-                (
-                  count (
-                    cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
-                  )
-                  - 1
-                )
-                /
-                count (
-                  cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
-                )
-              )
-            )
-        record: sre:node_infra:excessive_consumption_memory
-      ## If either of the CPU or Memory resource consumption alerts (see below) fire, then trigger an alert for SRE
-      - expr: (
-                count(
-                  ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h", alertstate="firing"}
-                  OR
-                  ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
-                ) >= 1
-              )
-        record: sre:node_infras:need_resize
   - name: sre-infra-resizing-alerts
     rules:
-      - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE1h
-        expr: sre:node_infra:excessive_consumption_cpu > 0
-        for: 1h
-        labels:
-          severity: warning
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 1 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
-      ## While individual spikes in CPU usage are acceptable, even if spikes are flappy, because CPU is a renewable resource,
-      ## long term (8h) CPU consumption above the threshold indicates CPU consumption has outgrown the cluster
-      - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
-        expr: sre:node_infra:excessive_consumption_cpu > 0
-        for: 16h
-        labels:
-          severity: warning
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
-      ## Given memory may be allocated but unused, 24h is good enough to catch gradual outgrowing of the cluster with critical node failures alerting via other alerts
-      - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
-        expr: sre:node_infra:excessive_consumption_memory > 0
-        for: 24h
-        labels:
-          severity: warning
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
-      ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
+      ## Pages SRE when any per-node N-1 infra resize alert is firing.
+      ## Covers extreme (90%, 45m/30m), short window (85%/80%, 1h), and long window (75%/70%, 12h) tiers.
       - alert: InfraNodesNeedResizingSRE
-        expr: sre:node_infras:need_resize > 0
-        for: 5m
+        expr: |
+          count(
+            ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m", alertstate="firing"}
+            OR
+            ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionPerNodeSRE30m", alertstate="firing"}
+            OR
+            ALERTS{alertname="cpu-InfraNodesNeedResizingSRE1h", alertstate="firing"}
+            OR
+            ALERTS{alertname="cpu-InfraNodesNeedResizingSRE12h", alertstate="firing"}
+            OR
+            ALERTS{alertname="memory-InfraNodesNeedResizingSRE1h", alertstate="firing"}
+            OR
+            ALERTS{alertname="memory-InfraNodesNeedResizingSRE12h", alertstate="firing"}
+          ) >= 1
+        for: 1m
         labels:
           severity: critical
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."
+          message: "The cluster's infrastructure nodes need to be vertically scaled. At least N-1 infra nodes have exceeded resource utilization thresholds. See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -44773,68 +44773,24 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: sre-infra-resource-consumption-recording.rules
-          rules:
-          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[1h]
-              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="infra"},
-              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) )
-            record: sre:node_infra:excessive_consumption_cpu
-          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
-              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
-              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
-              AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) )
-            record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
-              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
-              alertstate="firing"} ) >= 1 )
-            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE1h
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 1h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 1 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 16h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_memory > 0
-            for: 24h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and may need to be vertically scaled to support
-                the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 5m
+            expr: "count(\n  ALERTS{alertname=\"cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesExcessiveResourceConsumptionPerNodeSRE30m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n) >= 1\n"
+            for: 1m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's infrastructure nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's infrastructure nodes need to be vertically scaled.
+                At least N-1 infra nodes have exceeded resource utilization thresholds.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -45943,7 +45899,7 @@ objects:
               '
             for: 45m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% CPU for 45 minutes
@@ -45966,7 +45922,7 @@ objects:
               '
             for: 30m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% memory for 30 minutes

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -44773,68 +44773,24 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: sre-infra-resource-consumption-recording.rules
-          rules:
-          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[1h]
-              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="infra"},
-              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) )
-            record: sre:node_infra:excessive_consumption_cpu
-          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
-              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
-              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
-              AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) )
-            record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
-              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
-              alertstate="firing"} ) >= 1 )
-            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE1h
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 1h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 1 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 16h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_memory > 0
-            for: 24h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and may need to be vertically scaled to support
-                the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 5m
+            expr: "count(\n  ALERTS{alertname=\"cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesExcessiveResourceConsumptionPerNodeSRE30m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n) >= 1\n"
+            for: 1m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's infrastructure nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's infrastructure nodes need to be vertically scaled.
+                At least N-1 infra nodes have exceeded resource utilization thresholds.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -45943,7 +45899,7 @@ objects:
               '
             for: 45m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% CPU for 45 minutes
@@ -45966,7 +45922,7 @@ objects:
               '
             for: 30m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% memory for 30 minutes

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -44773,68 +44773,24 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
-        - name: sre-infra-resource-consumption-recording.rules
-          rules:
-          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[1h]
-              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="infra"},
-              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) )
-            record: sre:node_infra:excessive_consumption_cpu
-          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
-              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
-              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
-              AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) )
-            record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
-              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
-              alertstate="firing"} ) >= 1 )
-            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE1h
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 1h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 1 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_cpu > 0
-            for: 16h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and may need to be vertically scaled to support the
-                existing workers. See linked SOP for details.
-          - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
-            expr: sre:node_infra:excessive_consumption_memory > 0
-            for: 24h
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and may need to be vertically scaled to support
-                the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 5m
+            expr: "count(\n  ALERTS{alertname=\"cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesExcessiveResourceConsumptionPerNodeSRE30m\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"cpu-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE1h\"\
+              , alertstate=\"firing\"}\n  OR\n  ALERTS{alertname=\"memory-InfraNodesNeedResizingSRE12h\"\
+              , alertstate=\"firing\"}\n) >= 1\n"
+            for: 1m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's infrastructure nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's infrastructure nodes need to be vertically scaled.
+                At least N-1 infra nodes have exceeded resource utilization thresholds.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -45943,7 +45899,7 @@ objects:
               '
             for: 45m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% CPU for 45 minutes
@@ -45966,7 +45922,7 @@ objects:
               '
             for: 30m
             labels:
-              severity: warning
+              severity: high
               namespace: openshift-monitoring
             annotations:
               summary: Infra node above 90% memory for 30 minutes


### PR DESCRIPTION
## Summary

Promotes the per-node infra resize alerts (soaked under [ROSAENG-4043](https://redhat.atlassian.net/browse/ROSAENG-4043) and [ROSAENG-61749](https://redhat.atlassian.net/browse/ROSAENG-61749)) from warning-only to paging SRE, and removes the superseded cluster-wide recording rules and alerts.

- **ExtremelyHighIndividualInfraNode{CPU,Memory}SRE**: `severity: warning` → `severity: high`. These are singleton alerts (1 node at 90%+, fewer than N-1 affected) that indicate anomalous workload on a specific node — investigation-focused, not resize-focused.
- **InfraNodesNeedResizingSRE**: Rewrites the expression from the old cluster-wide average recording rule (`sre:node_infras:need_resize`) to fire when any per-node N-1 resize warning is active. Covers three tiers:
  - Extreme (90%, 45m CPU / 30m memory)
  - Short window (85% CPU / 80% memory, 1h)
  - Long window (75% CPU / 70% memory, 12h)
- Reduces `InfraNodesNeedResizingSRE` `for` from 5m to 1m — upstream warnings have already sustained for 30m–12h before reaching `firing` state, so additional debounce is unnecessary.
- **Removes** old cluster-wide recording rules (`sre:node_infra:excessive_consumption_cpu`, `sre:node_infra:excessive_consumption_memory`, `sre:node_infras:need_resize`) and their associated alerts (`cpu-InfraNodesExcessiveResourceConsumptionSRE1h`, `cpu-InfraNodesExcessiveResourceConsumptionSRE`, `memory-InfraNodesExcessiveResourceConsumptionSRE`). These are only referenced within the same file and are fully superseded by the per-node alerting strategy.

### Alert routing after this change

| Alert | Severity | Pages? | Scenario |
|-------|----------|--------|----------|
| ExtremelyHighIndividualInfraNodeCPUSRE | high | Yes (direct) | 1 node > 90% CPU, < N-1 affected |
| ExtremelyHighIndividualInfraNodeMemorySRE | high | Yes (direct) | 1 node > 90% mem, < N-1 affected |
| InfraNodesNeedResizingSRE | critical | Yes (composite) | N-1 nodes exceed any resize threshold |
| All other per-node alerts | warning | No | Feeder signals for the above |

## Jira
- [ROSAENG-4043](https://redhat.atlassian.net/browse/ROSAENG-4043)
- [ROSAENG-61749](https://redhat.atlassian.net/browse/ROSAENG-61749)

## Test plan
- [ ] `make` generates templates successfully for all environments
- [ ] YAML validation passes
- [ ] Verify PromQL expressions are syntactically valid
- [ ] Confirm no clusters currently firing would immediately page (checked via telemeter — clusters in limited support excluded, MC resizes completed under [OHSS-56805](https://redhat.atlassian.net/browse/OHSS-56805))

🤖 Generated with [Claude Code](https://claude.com/claude-code)