### PR TITLE
Add runbook_url to infra node alerts and fix CI check coverage

### DIFF
--- a/deploy/sre-prometheus-per-node-infra/100-infra-per-node-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus-per-node-infra/100-infra-per-node-resizing.PrometheusRule.yaml
@@ -81,6 +81,7 @@ spec:
         annotations:
           summary: "Infra node above 90% CPU for 45 minutes"
           description: "An infrastructure node has had CPU utilization above 90% for 45 minutes, but fewer than N-1 nodes are affected. This indicates anomalous resource consumption on a specific node rather than a cluster-wide capacity issue. Investigate the node's workloads."
+          runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeCPUSRE.md
       - alert: ExtremelyHighIndividualInfraNodeMemorySRE
         expr: |
           count(sre:node_infra:memory_utilization_per_node > 0.90) >= 1
@@ -95,6 +96,7 @@ spec:
         annotations:
           summary: "Infra node above 90% memory for 30 minutes"
           description: "An infrastructure node has had memory utilization above 90% for 30 minutes, but fewer than N-1 nodes are affected. This indicates anomalous resource consumption on a specific node rather than a cluster-wide capacity issue. Investigate the node's workloads."
+          runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeMemorySRE.md
       - alert: cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m
         expr: |
           count(sre:node_infra:cpu_utilization_per_node > 0.90)

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45907,6 +45907,7 @@ objects:
                 for 45 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeCPUSRE.md
           - alert: ExtremelyHighIndividualInfraNodeMemorySRE
             expr: 'count(sre:node_infra:memory_utilization_per_node > 0.90) >= 1
 
@@ -45930,6 +45931,7 @@ objects:
                 90% for 30 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeMemorySRE.md
           - alert: cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m
             expr: 'count(sre:node_infra:cpu_utilization_per_node > 0.90)
 

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45907,6 +45907,7 @@ objects:
                 for 45 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeCPUSRE.md
           - alert: ExtremelyHighIndividualInfraNodeMemorySRE
             expr: 'count(sre:node_infra:memory_utilization_per_node > 0.90) >= 1
 
@@ -45930,6 +45931,7 @@ objects:
                 90% for 30 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeMemorySRE.md
           - alert: cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m
             expr: 'count(sre:node_infra:cpu_utilization_per_node > 0.90)
 

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45907,6 +45907,7 @@ objects:
                 for 45 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeCPUSRE.md
           - alert: ExtremelyHighIndividualInfraNodeMemorySRE
             expr: 'count(sre:node_infra:memory_utilization_per_node > 0.90) >= 1
 
@@ -45930,6 +45931,7 @@ objects:
                 90% for 30 minutes, but fewer than N-1 nodes are affected. This indicates
                 anomalous resource consumption on a specific node rather than a cluster-wide
                 capacity issue. Investigate the node's workloads.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeMemorySRE.md
           - alert: cpu-InfraNodesExcessiveResourceConsumptionPerNodeSRE45m
             expr: 'count(sre:node_infra:cpu_utilization_per_node > 0.90)
 

--- a/scripts/check-prometheusrules.py
+++ b/scripts/check-prometheusrules.py
@@ -31,6 +31,8 @@ _VALID_SEVERITY_RE = re.compile(r'^(critical|warning|info)$')
 
 _SEARCH_DIRS = [
     Path('.', 'deploy/sre-prometheus'),
+    Path('.', 'deploy/sre-prometheus-must-gather'),
+    Path('.', 'deploy/sre-prometheus-per-node-infra'),
 ]
 
 # Pre-existing alerts with missing or invalid severity labels.


### PR DESCRIPTION
## Summary

- Add `runbook_url` annotations to `ExtremelyHighIndividualInfraNodeCPUSRE` and `ExtremelyHighIndividualInfraNodeMemorySRE` (promoted to critical in #2834, missing runbook_url causing STS conformance test failures)
- Add `deploy/sre-prometheus-per-node-infra/` to `check-prometheusrules.py` search directories so CI catches missing annotations in that path going forward

SOPs already exist:
- https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeCPUSRE.md
- https://github.com/openshift/ops-sop/blob/master/v4/alerts/ExtremelyHighIndividualInfraNodeMemorySRE.md

Fixes: [OSD-21709](https://redhat.atlassian.net/browse/OSD-21709)

## Test plan

- [ ] CI check-prometheusrules passes
- [ ] STS conformance nightly passes the runbook_url annotation test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added runbook links to high CPU and high memory infrastructure-node alerts for easier troubleshooting.

* **Monitoring**
  * Expanded automated Prometheus rule checks to include infrastructure-node alert definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->