### PR TITLE
update the pre-submit check to cover all the files under deploy

### DIFF
--- a/scripts/check-prometheusrules.py
+++ b/scripts/check-prometheusrules.py
@@ -30,9 +30,7 @@ import oyaml as yaml
 _VALID_SEVERITY_RE = re.compile(r'^(critical|warning|info)$')
 
 _SEARCH_DIRS = [
-    Path('.', 'deploy/sre-prometheus'),
-    Path('.', 'deploy/sre-prometheus-must-gather'),
-    Path('.', 'deploy/sre-prometheus-per-node-infra'),
+    Path('.', 'deploy'),
 ]
 
 # Pre-existing alerts with missing or invalid severity labels.
@@ -372,6 +370,11 @@ def main():
         default=_SEARCH_DIRS,
         help='Directories to search for PrometheusRule YAML files',
     )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Print each file and alerting rule as it is checked',
+    )
     args = parser.parse_args()
 
     prom_files, file_errors = _find_prometheusrule_files(args.directories)
@@ -386,9 +389,13 @@ def main():
     all_violations = []
 
     for path, doc in prom_files:
+        if args.verbose:
+            print(f'  Checking file: {path}')
         alerting_rules = _extract_alerting_rules(doc)
         for group_name, rule in alerting_rules:
             alert_name = rule.get('alert', '<unnamed>')
+            if args.verbose:
+                print(f'    Checking alert: {alert_name} (group: {group_name})')
             for check in _CHECKS:
                 for violation in check(alert_name, rule):
                     all_violations.append(


### PR DESCRIPTION
### What type of PR is this?
_(fix)_

### What this PR does / why we need it?

Fix the check_prometheusrules.py to check all the files under deploy/.
It was assuming all the premetheusrules are under sre-prometheus/, but with some recent change, we have prometheus rules stored in multiple different places.

Also adding verbose output for local debug. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Prometheus rule validation to include files in the deployment directory.
  * Added a verbose mode that displays each checked file and alerting rule.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->