### PR TITLE
chore(ROSAENG-64728): ignores MUO healthchecks for alerts related to missing RHOBS stack on MCs

### DIFF
--- a/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
@@ -41,6 +41,8 @@ data:
       - ControlPlaneNodeFileDescriptorLimitSRE
       - ControlPlaneNodeFilesystemAlmostOutOfFiles
       - ControlPlaneNodeFilesystemSpaceFillingUp
+      - COOWorkloadMissingSRE
+      - COOWorkloadDegradedSRE
       - CustomerWorkloadPreventingDrainSRE
       - EbsVolumeBurstBalanceLT20PctSRE
       - EbsVolumeStuckAttaching10MinSRE

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32101,11 +32101,12 @@ objects:
           \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
           \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
           \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
-          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
-          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
-          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
-          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
-          \  - HAProxyDownSRE\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - COOWorkloadMissingSRE\n  - COOWorkloadDegradedSRE\n  - CustomerWorkloadPreventingDrainSRE\n\
+          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
+          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
+          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
+          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDownSRE\n  -\
+          \ HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
           \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
           \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
           \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32101,11 +32101,12 @@ objects:
           \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
           \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
           \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
-          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
-          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
-          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
-          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
-          \  - HAProxyDownSRE\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - COOWorkloadMissingSRE\n  - COOWorkloadDegradedSRE\n  - CustomerWorkloadPreventingDrainSRE\n\
+          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
+          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
+          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
+          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDownSRE\n  -\
+          \ HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
           \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
           \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
           \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32101,11 +32101,12 @@ objects:
           \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
           \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
           \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
-          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
-          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
-          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
-          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
-          \  - HAProxyDownSRE\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - COOWorkloadMissingSRE\n  - COOWorkloadDegradedSRE\n  - CustomerWorkloadPreventingDrainSRE\n\
+          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
+          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
+          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
+          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDownSRE\n  -\
+          \ HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
           \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
           \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
           \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

Instructs MUO to ignore healthchecks for critical alerts related to the absence of the RHOBS stack on Management Clusters. Not all Management Clusters in lower environments have the RHOBS stack installed so these checks can prevent upgrades. In production the absence of the RHOBS stack does not generally relate to platform health so these losing these checks has little impact

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [ROSAENG-64728](https://redhat.atlassian.net/browse/ROSAENG-64728)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented selected workload health alerts from being treated as critical during managed upgrade operations.
  * Reduced unnecessary upgrade-related alert noise for affected workload conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->