### PR TITLE
itn-2026-00255: create job to cleanup ocmagent CR

### DIFF
--- a/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/00-ServiceAccount.yaml
+++ b/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/00-ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocmagent-finalizer-cleanup-sa
+  namespace: openshift-monitoring

--- a/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/01-ClusterRole.yaml
+++ b/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/01-ClusterRole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ocmagent-finalizer-cleanup-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - "ocmagent.managed.openshift.io"
+  resources:
+  - ocmagents
+  verbs:
+  - get
+  - list
+  - patch

--- a/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/02-ClusterRoleBinding.yaml
+++ b/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/02-ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocmagent-finalizer-cleanup-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocmagent-finalizer-cleanup-role
+subjects:
+- kind: ServiceAccount
+  name: ocmagent-finalizer-cleanup-sa
+  namespace: openshift-monitoring

--- a/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/03-Job.yaml
+++ b/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/03-Job.yaml
@@ -1,0 +1,123 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ocmagent-finalizer-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    kubernetes.io/description: "Remove finalizers from OcmAgent CRs blocking namespace termination"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 43200
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      name: ocmagent-finalizer-cleanup
+    spec:
+      serviceAccountName: ocmagent-finalizer-cleanup-sa
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      containers:
+      - name: cleanup
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          NAMESPACE="openshift-ocm-agent-operator"
+          CR_RESOURCE="ocmagents.ocmagent.managed.openshift.io"
+
+          echo "=========================================="
+          echo "OcmAgent Finalizer Cleanup"
+          echo "=========================================="
+          echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo ""
+
+          # Step 1: Check if the namespace exists and is in Terminating state
+          NS_OUTPUT=$(oc get namespace "${NAMESPACE}" --ignore-not-found -o jsonpath='{.status.phase}')
+
+          if [ -z "${NS_OUTPUT}" ]; then
+            echo "Namespace ${NAMESPACE} does not exist. Nothing to do."
+            exit 0
+          fi
+
+          echo "Namespace ${NAMESPACE} phase: ${NS_OUTPUT}"
+
+          if [ "${NS_OUTPUT}" != "Terminating" ]; then
+            echo "Namespace is not in Terminating state. No action needed."
+            exit 0
+          fi
+
+          echo "Namespace is Terminating. Checking for OcmAgent CRs with finalizers..."
+          echo ""
+
+          # Step 2: Get all OcmAgent CRs in the namespace
+          CR_NAMES=$(oc get ${CR_RESOURCE} -n "${NAMESPACE}" --ignore-not-found -o jsonpath='{.items[*].metadata.name}')
+
+          if [ -z "${CR_NAMES}" ]; then
+            echo "No OcmAgent CRs found in namespace ${NAMESPACE}."
+            echo "Namespace may be blocked by other resources."
+            exit 0
+          fi
+
+          # Step 3: Remove finalizers from each CR
+          CLEANED=0
+          FAILED=0
+          SKIPPED=0
+
+          for name in ${CR_NAMES}; do
+            CR_JSON=$(oc get ${CR_RESOURCE} "${name}" -n "${NAMESPACE}" --ignore-not-found -o jsonpath='{.metadata.deletionTimestamp}{"\t"}{.metadata.finalizers}')
+            DELETION_TS=$(echo "${CR_JSON}" | cut -f1)
+            FINALIZERS=$(echo "${CR_JSON}" | cut -f2)
+
+            if [ -z "${DELETION_TS}" ]; then
+              echo "[SKIP] ${name} - no deletionTimestamp, not pending deletion"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            if [ -z "${FINALIZERS}" ] || [ "${FINALIZERS}" = "[]" ]; then
+              echo "[SKIP] ${name} - no finalizers"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            echo "[PATCH] ${name} - deletionTimestamp=${DELETION_TS}, removing finalizers: ${FINALIZERS}"
+            if oc patch ${CR_RESOURCE} "${name}" -n "${NAMESPACE}" --type=merge -p '{"metadata":{"finalizers":null}}'; then
+              echo "  OK: finalizers removed"
+              CLEANED=$((CLEANED + 1))
+            else
+              echo "  FAIL: could not remove finalizers"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "Summary: cleaned=${CLEANED} skipped=${SKIPPED} failed=${FAILED}"
+          echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "=========================================="
+
+          if [ "${FAILED}" -gt 0 ]; then
+            exit 1
+          fi

--- a/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/config.yaml
+++ b/deploy/itn-2026-00255-ocmagent-finalizer-cleanup/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31699,6 +31699,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2026-00255-ocmagent-finalizer-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocmagent-finalizer-cleanup-role
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - ocmagents
+        verbs:
+        - get
+        - list
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ocmagent-finalizer-cleanup-rb
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocmagent-finalizer-cleanup-role
+      subjects:
+      - kind: ServiceAccount
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: ocmagent-finalizer-cleanup
+        namespace: openshift-monitoring
+        annotations:
+          kubernetes.io/description: Remove finalizers from OcmAgent CRs blocking
+            namespace termination
+      spec:
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 43200
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: ocmagent-finalizer-cleanup
+          spec:
+            serviceAccountName: ocmagent-finalizer-cleanup-sa
+            restartPolicy: Never
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            containers:
+            - name: cleanup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nNAMESPACE=\"openshift-ocm-agent-operator\"\
+                \nCR_RESOURCE=\"ocmagents.ocmagent.managed.openshift.io\"\n\necho\
+                \ \"==========================================\"\necho \"OcmAgent\
+                \ Finalizer Cleanup\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Check if the namespace exists and is in Terminating state\n\
+                NS_OUTPUT=$(oc get namespace \"${NAMESPACE}\" --ignore-not-found -o\
+                \ jsonpath='{.status.phase}')\n\nif [ -z \"${NS_OUTPUT}\" ]; then\n\
+                \  echo \"Namespace ${NAMESPACE} does not exist. Nothing to do.\"\n\
+                \  exit 0\nfi\n\necho \"Namespace ${NAMESPACE} phase: ${NS_OUTPUT}\"\
+                \n\nif [ \"${NS_OUTPUT}\" != \"Terminating\" ]; then\n  echo \"Namespace\
+                \ is not in Terminating state. No action needed.\"\n  exit 0\nfi\n\
+                \necho \"Namespace is Terminating. Checking for OcmAgent CRs with\
+                \ finalizers...\"\necho \"\"\n\n# Step 2: Get all OcmAgent CRs in\
+                \ the namespace\nCR_NAMES=$(oc get ${CR_RESOURCE} -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.items[*].metadata.name}')\n\n\
+                if [ -z \"${CR_NAMES}\" ]; then\n  echo \"No OcmAgent CRs found in\
+                \ namespace ${NAMESPACE}.\"\n  echo \"Namespace may be blocked by\
+                \ other resources.\"\n  exit 0\nfi\n\n# Step 3: Remove finalizers\
+                \ from each CR\nCLEANED=0\nFAILED=0\nSKIPPED=0\n\nfor name in ${CR_NAMES};\
+                \ do\n  CR_JSON=$(oc get ${CR_RESOURCE} \"${name}\" -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.metadata.deletionTimestamp}{\"\
+                \\t\"}{.metadata.finalizers}')\n  DELETION_TS=$(echo \"${CR_JSON}\"\
+                \ | cut -f1)\n  FINALIZERS=$(echo \"${CR_JSON}\" | cut -f2)\n\n  if\
+                \ [ -z \"${DELETION_TS}\" ]; then\n    echo \"[SKIP] ${name} - no\
+                \ deletionTimestamp, not pending deletion\"\n    SKIPPED=$((SKIPPED\
+                \ + 1))\n    continue\n  fi\n\n  if [ -z \"${FINALIZERS}\" ] || [\
+                \ \"${FINALIZERS}\" = \"[]\" ]; then\n    echo \"[SKIP] ${name} -\
+                \ no finalizers\"\n    SKIPPED=$((SKIPPED + 1))\n    continue\n  fi\n\
+                \n  echo \"[PATCH] ${name} - deletionTimestamp=${DELETION_TS}, removing\
+                \ finalizers: ${FINALIZERS}\"\n  if oc patch ${CR_RESOURCE} \"${name}\"\
+                \ -n \"${NAMESPACE}\" --type=merge -p '{\"metadata\":{\"finalizers\"\
+                :null}}'; then\n    echo \"  OK: finalizers removed\"\n    CLEANED=$((CLEANED\
+                \ + 1))\n  else\n    echo \"  FAIL: could not remove finalizers\"\n\
+                \    FAILED=$((FAILED + 1))\n  fi\ndone\n\necho \"\"\necho \"==========================================\"\
+                \necho \"Summary: cleaned=${CLEANED} skipped=${SKIPPED} failed=${FAILED}\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"==========================================\"\
+                \n\nif [ \"${FAILED}\" -gt 0 ]; then\n  exit 1\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31699,6 +31699,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2026-00255-ocmagent-finalizer-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocmagent-finalizer-cleanup-role
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - ocmagents
+        verbs:
+        - get
+        - list
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ocmagent-finalizer-cleanup-rb
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocmagent-finalizer-cleanup-role
+      subjects:
+      - kind: ServiceAccount
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: ocmagent-finalizer-cleanup
+        namespace: openshift-monitoring
+        annotations:
+          kubernetes.io/description: Remove finalizers from OcmAgent CRs blocking
+            namespace termination
+      spec:
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 43200
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: ocmagent-finalizer-cleanup
+          spec:
+            serviceAccountName: ocmagent-finalizer-cleanup-sa
+            restartPolicy: Never
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            containers:
+            - name: cleanup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nNAMESPACE=\"openshift-ocm-agent-operator\"\
+                \nCR_RESOURCE=\"ocmagents.ocmagent.managed.openshift.io\"\n\necho\
+                \ \"==========================================\"\necho \"OcmAgent\
+                \ Finalizer Cleanup\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Check if the namespace exists and is in Terminating state\n\
+                NS_OUTPUT=$(oc get namespace \"${NAMESPACE}\" --ignore-not-found -o\
+                \ jsonpath='{.status.phase}')\n\nif [ -z \"${NS_OUTPUT}\" ]; then\n\
+                \  echo \"Namespace ${NAMESPACE} does not exist. Nothing to do.\"\n\
+                \  exit 0\nfi\n\necho \"Namespace ${NAMESPACE} phase: ${NS_OUTPUT}\"\
+                \n\nif [ \"${NS_OUTPUT}\" != \"Terminating\" ]; then\n  echo \"Namespace\
+                \ is not in Terminating state. No action needed.\"\n  exit 0\nfi\n\
+                \necho \"Namespace is Terminating. Checking for OcmAgent CRs with\
+                \ finalizers...\"\necho \"\"\n\n# Step 2: Get all OcmAgent CRs in\
+                \ the namespace\nCR_NAMES=$(oc get ${CR_RESOURCE} -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.items[*].metadata.name}')\n\n\
+                if [ -z \"${CR_NAMES}\" ]; then\n  echo \"No OcmAgent CRs found in\
+                \ namespace ${NAMESPACE}.\"\n  echo \"Namespace may be blocked by\
+                \ other resources.\"\n  exit 0\nfi\n\n# Step 3: Remove finalizers\
+                \ from each CR\nCLEANED=0\nFAILED=0\nSKIPPED=0\n\nfor name in ${CR_NAMES};\
+                \ do\n  CR_JSON=$(oc get ${CR_RESOURCE} \"${name}\" -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.metadata.deletionTimestamp}{\"\
+                \\t\"}{.metadata.finalizers}')\n  DELETION_TS=$(echo \"${CR_JSON}\"\
+                \ | cut -f1)\n  FINALIZERS=$(echo \"${CR_JSON}\" | cut -f2)\n\n  if\
+                \ [ -z \"${DELETION_TS}\" ]; then\n    echo \"[SKIP] ${name} - no\
+                \ deletionTimestamp, not pending deletion\"\n    SKIPPED=$((SKIPPED\
+                \ + 1))\n    continue\n  fi\n\n  if [ -z \"${FINALIZERS}\" ] || [\
+                \ \"${FINALIZERS}\" = \"[]\" ]; then\n    echo \"[SKIP] ${name} -\
+                \ no finalizers\"\n    SKIPPED=$((SKIPPED + 1))\n    continue\n  fi\n\
+                \n  echo \"[PATCH] ${name} - deletionTimestamp=${DELETION_TS}, removing\
+                \ finalizers: ${FINALIZERS}\"\n  if oc patch ${CR_RESOURCE} \"${name}\"\
+                \ -n \"${NAMESPACE}\" --type=merge -p '{\"metadata\":{\"finalizers\"\
+                :null}}'; then\n    echo \"  OK: finalizers removed\"\n    CLEANED=$((CLEANED\
+                \ + 1))\n  else\n    echo \"  FAIL: could not remove finalizers\"\n\
+                \    FAILED=$((FAILED + 1))\n  fi\ndone\n\necho \"\"\necho \"==========================================\"\
+                \necho \"Summary: cleaned=${CLEANED} skipped=${SKIPPED} failed=${FAILED}\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"==========================================\"\
+                \n\nif [ \"${FAILED}\" -gt 0 ]; then\n  exit 1\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31699,6 +31699,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2026-00255-ocmagent-finalizer-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocmagent-finalizer-cleanup-role
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - ocmagents
+        verbs:
+        - get
+        - list
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ocmagent-finalizer-cleanup-rb
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocmagent-finalizer-cleanup-role
+      subjects:
+      - kind: ServiceAccount
+        name: ocmagent-finalizer-cleanup-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: ocmagent-finalizer-cleanup
+        namespace: openshift-monitoring
+        annotations:
+          kubernetes.io/description: Remove finalizers from OcmAgent CRs blocking
+            namespace termination
+      spec:
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 43200
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: ocmagent-finalizer-cleanup
+          spec:
+            serviceAccountName: ocmagent-finalizer-cleanup-sa
+            restartPolicy: Never
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            containers:
+            - name: cleanup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\nNAMESPACE=\"openshift-ocm-agent-operator\"\
+                \nCR_RESOURCE=\"ocmagents.ocmagent.managed.openshift.io\"\n\necho\
+                \ \"==========================================\"\necho \"OcmAgent\
+                \ Finalizer Cleanup\"\necho \"==========================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Check if the namespace exists and is in Terminating state\n\
+                NS_OUTPUT=$(oc get namespace \"${NAMESPACE}\" --ignore-not-found -o\
+                \ jsonpath='{.status.phase}')\n\nif [ -z \"${NS_OUTPUT}\" ]; then\n\
+                \  echo \"Namespace ${NAMESPACE} does not exist. Nothing to do.\"\n\
+                \  exit 0\nfi\n\necho \"Namespace ${NAMESPACE} phase: ${NS_OUTPUT}\"\
+                \n\nif [ \"${NS_OUTPUT}\" != \"Terminating\" ]; then\n  echo \"Namespace\
+                \ is not in Terminating state. No action needed.\"\n  exit 0\nfi\n\
+                \necho \"Namespace is Terminating. Checking for OcmAgent CRs with\
+                \ finalizers...\"\necho \"\"\n\n# Step 2: Get all OcmAgent CRs in\
+                \ the namespace\nCR_NAMES=$(oc get ${CR_RESOURCE} -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.items[*].metadata.name}')\n\n\
+                if [ -z \"${CR_NAMES}\" ]; then\n  echo \"No OcmAgent CRs found in\
+                \ namespace ${NAMESPACE}.\"\n  echo \"Namespace may be blocked by\
+                \ other resources.\"\n  exit 0\nfi\n\n# Step 3: Remove finalizers\
+                \ from each CR\nCLEANED=0\nFAILED=0\nSKIPPED=0\n\nfor name in ${CR_NAMES};\
+                \ do\n  CR_JSON=$(oc get ${CR_RESOURCE} \"${name}\" -n \"${NAMESPACE}\"\
+                \ --ignore-not-found -o jsonpath='{.metadata.deletionTimestamp}{\"\
+                \\t\"}{.metadata.finalizers}')\n  DELETION_TS=$(echo \"${CR_JSON}\"\
+                \ | cut -f1)\n  FINALIZERS=$(echo \"${CR_JSON}\" | cut -f2)\n\n  if\
+                \ [ -z \"${DELETION_TS}\" ]; then\n    echo \"[SKIP] ${name} - no\
+                \ deletionTimestamp, not pending deletion\"\n    SKIPPED=$((SKIPPED\
+                \ + 1))\n    continue\n  fi\n\n  if [ -z \"${FINALIZERS}\" ] || [\
+                \ \"${FINALIZERS}\" = \"[]\" ]; then\n    echo \"[SKIP] ${name} -\
+                \ no finalizers\"\n    SKIPPED=$((SKIPPED + 1))\n    continue\n  fi\n\
+                \n  echo \"[PATCH] ${name} - deletionTimestamp=${DELETION_TS}, removing\
+                \ finalizers: ${FINALIZERS}\"\n  if oc patch ${CR_RESOURCE} \"${name}\"\
+                \ -n \"${NAMESPACE}\" --type=merge -p '{\"metadata\":{\"finalizers\"\
+                :null}}'; then\n    echo \"  OK: finalizers removed\"\n    CLEANED=$((CLEANED\
+                \ + 1))\n  else\n    echo \"  FAIL: could not remove finalizers\"\n\
+                \    FAILED=$((FAILED + 1))\n  fi\ndone\n\necho \"\"\necho \"==========================================\"\
+                \necho \"Summary: cleaned=${CLEANED} skipped=${SKIPPED} failed=${FAILED}\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"==========================================\"\
+                \n\nif [ \"${FAILED}\" -gt 0 ]; then\n  exit 1\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

To cleanup the ocmagent CR from the namespace which is blocking the PKO deployment

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated cleanup job for OpenShift monitoring resources stuck during namespace termination.
  * The job removes blocking finalizers from eligible resources and reports successful, skipped, and failed cleanup actions.
  * Added the required permissions and service account configuration for secure execution.
  * Configured resource synchronization while excluding FedRAMP-labeled resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->