### PR TITLE
Add 2h pending period to CannotRetrieveUpdatesSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
@@ -28,12 +28,13 @@ spec:
             end }}{{ end }}
           summary: Cluster version operator has not retrieved updates.
         expr: '
-            (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 
-          and ignoring(condition, name, reason) 
+            (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600
+          and ignoring(condition, name, reason)
             (cluster_operator_conditions{name="version",condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"})
           and on(instance, job, namespace, pod, service)
             (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"})
           '
+        for: 2h
         labels:
           severity: critical
           namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45668,6 +45668,7 @@ objects:
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
               pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            for: 2h
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45668,6 +45668,7 @@ objects:
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
               pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            for: 2h
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45668,6 +45668,7 @@ objects:
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
               pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            for: 2h
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'


### PR DESCRIPTION
## Summary

- Adds `for: 2h` to the `CannotRetrieveUpdatesSRE` alert rule
- The alert currently has no `for:` duration, so it fires the instant the CVO hasn't retrieved updates for 1 hour. This causes noisy pages on newly created clusters where the update service graph or network connectivity hasn't stabilized yet.
- With `for: 2h`, the condition must persist for 2 continuous hours in the pending state before it actually fires, filtering out transient failures on new clusters while still catching real issues on established ones.

## Context

Slack thread: https://redhat-internal.slack.com/archives/C0ADGRNAT8U/p1786114195992469

## Test plan

- [ ] Verify the PrometheusRule YAML is valid
- [ ] Confirm `for: 2h` is correctly placed in the alert rule
- [ ] Validate that the alert still fires for clusters with persistent update retrieval failures (after 2h pending)
- [ ] Confirm newly provisioned clusters no longer trigger immediate pages during bootstrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up formatting in the Prometheus alert configuration.
  * Confirmed the alert condition and two-hour duration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->