### PR TITLE
[ROSAENG-64801]Add alert for managed namespaces stuck in Terminating state

### DIFF
--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -11,7 +11,9 @@ spec:
   - name: sre-namespace-stuck-terminating
     rules:
     - expr: |
-        kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+        kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
+        or
+        kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1
       record: sre:record:namespace_stuck_terminating
     - alert: ManagedNamespaceStuckTerminatingSRE
       expr: |

--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -11,9 +11,11 @@ spec:
   - name: sre-namespace-stuck-terminating
     rules:
     - expr: |
-        kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
-        or
-        kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1
+        max by (namespace) (
+          kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
+          or
+          kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1
+        )
       record: sre:record:namespace_stuck_terminating
     - alert: ManagedNamespaceStuckTerminatingSRE
       expr: |

--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -11,10 +11,13 @@ spec:
   - name: sre-namespace-stuck-terminating
     rules:
     - expr: |
-        max by (namespace) (
+        max by (namespace, phase) (
           kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
           or
-          kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1
+          label_replace(
+            kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1,
+            "phase", "Terminating", "", ""
+          )
         )
       record: sre:record:namespace_stuck_terminating
     - alert: ManagedNamespaceStuckTerminatingSRE

--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -11,14 +11,7 @@ spec:
   - name: sre-namespace-stuck-terminating
     rules:
     - expr: |
-        max by (namespace, phase) (
-          kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
-          or
-          label_replace(
-            kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining", status="true"} == 1,
-            "phase", "Terminating", "", ""
-          )
-        )
+        kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
       record: sre:record:namespace_stuck_terminating
     - alert: ManagedNamespaceStuckTerminatingSRE
       expr: |

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47985,6 +47985,12 @@ objects:
         - name: sre-namespace-stuck-terminating
           rules:
           - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              or
+
+              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
+              status="true"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47984,11 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
-              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
-              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
-              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              '
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47984,15 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
-
-              or
-
-              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
-              status="true"} == 1
-
-              '
+          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
+              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
+              , status=\"true\"} == 1\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47984,10 +47984,11 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
-              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
-              , status=\"true\"} == 1\n)\n"
+          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
+              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
+              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
+              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47985,6 +47985,12 @@ objects:
         - name: sre-namespace-stuck-terminating
           rules:
           - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              or
+
+              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
+              status="true"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47984,11 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
-              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
-              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
-              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              '
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47984,15 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
-
-              or
-
-              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
-              status="true"} == 1
-
-              '
+          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
+              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
+              , status=\"true\"} == 1\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47984,10 +47984,11 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
-              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
-              , status=\"true\"} == 1\n)\n"
+          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
+              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
+              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
+              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47985,6 +47985,12 @@ objects:
         - name: sre-namespace-stuck-terminating
           rules:
           - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              or
+
+              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
+              status="true"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47984,11 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
-              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
-              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
-              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
+              == 1
+
+              '
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47984,15 +47984,10 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
-
-              or
-
-              kube_namespace_status_condition{namespace=~"openshift-.*", condition=~"NamespaceContentRemaining|NamespaceFinalizersRemaining",
-              status="true"} == 1
-
-              '
+          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
+              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
+              , status=\"true\"} == 1\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47984,10 +47984,11 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: "max by (namespace) (\n  kube_namespace_status_phase{namespace=~\"\
-              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  kube_namespace_status_condition{namespace=~\"\
-              openshift-.*\", condition=~\"NamespaceContentRemaining|NamespaceFinalizersRemaining\"\
-              , status=\"true\"} == 1\n)\n"
+          - expr: "max by (namespace, phase) (\n  kube_namespace_status_phase{namespace=~\"\
+              openshift-.*\", phase=\"Terminating\"} == 1\n  or\n  label_replace(\n\
+              \    kube_namespace_status_condition{namespace=~\"openshift-.*\", condition=~\"\
+              NamespaceContentRemaining|NamespaceFinalizersRemaining\", status=\"\
+              true\"} == 1,\n    \"phase\", \"Terminating\", \"\", \"\"\n  )\n)\n"
             record: sre:record:namespace_stuck_terminating
           - alert: ManagedNamespaceStuckTerminatingSRE
             expr: 'sre:record:namespace_stuck_terminating


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Follow-up - https://github.com/openshift/managed-cluster-config/pull/2841
Updating recording rule, as it capture all active NS as well

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [ROSAENG-64801](https://redhat.atlassian.net/browse/ROSAENG-64801)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [X] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring alerts for namespaces stuck during termination.
  * Alerts now trigger only when the recorded terminating-namespace metric is active, reducing false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->