### PR TITLE
ROSAENG-61768: Allow unsigned nightly images on staging/int HCP MCs

### DIFF
--- a/deploy/allow-unsigned-nightly-images/00-Namespace.yaml
+++ b/deploy/allow-unsigned-nightly-images/00-Namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: allow-unsigned-nightly-images

--- a/deploy/allow-unsigned-nightly-images/01-ServiceAccount.yaml
+++ b/deploy/allow-unsigned-nightly-images/01-ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: allow-unsigned-nightly-images
+  namespace: allow-unsigned-nightly-images

--- a/deploy/allow-unsigned-nightly-images/02-ClusterRole.yaml
+++ b/deploy/allow-unsigned-nightly-images/02-ClusterRole.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-unsigned-nightly-images
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  - clusterimagepolicies
+  verbs:
+  - get
+  - list
+  - patch
+  - update

--- a/deploy/allow-unsigned-nightly-images/03-ClusterRoleBinding.yaml
+++ b/deploy/allow-unsigned-nightly-images/03-ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-unsigned-nightly-images
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-unsigned-nightly-images
+subjects:
+- kind: ServiceAccount
+  name: allow-unsigned-nightly-images
+  namespace: allow-unsigned-nightly-images

--- a/deploy/allow-unsigned-nightly-images/04-Job.yaml
+++ b/deploy/allow-unsigned-nightly-images/04-Job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: allow-unsigned-nightly-images
+  namespace: allow-unsigned-nightly-images
+  annotations:
+    kubernetes.io/description: "Allow unsigned nightly OCP images on staging/int MCs for HCP CI testing. 4.22 MCs enforce ClusterImagePolicy signature verification which rejects unsigned nightly images used by HCP control plane pods."
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      name: allow-unsigned-nightly-images
+    spec:
+      serviceAccountName: allow-unsigned-nightly-images
+      restartPolicy: Never
+      containers:
+      - name: allow-unsigned-nightly-images
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          echo "============================================"
+          echo "Allow unsigned nightly images on staging MCs"
+          echo "============================================"
+          echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo ""
+
+          # Step 1: Add CVO override to unmanage ClusterImagePolicy
+          echo "Adding CVO override for ClusterImagePolicy..."
+          oc patch clusterversion version --type=merge -p '{
+            "spec": {
+              "overrides": [
+                {
+                  "kind": "ClusterImagePolicy",
+                  "group": "config.openshift.io",
+                  "name": "openshift",
+                  "namespace": "",
+                  "unmanaged": true
+                }
+              ]
+            }
+          }'
+          echo "CVO override added."
+
+          # Step 2: Patch ClusterImagePolicy to only enforce signatures on released payloads
+          # Remove ocp-v4.0-art-dev and ocp-v5.0-art-dev scopes (nightly images)
+          # Keep ocp-release scope (signed released payloads)
+          echo "Patching ClusterImagePolicy scopes..."
+          oc patch clusterimagepolicy openshift --type=json -p '[
+            {"op": "replace", "path": "/spec/scopes", "value": ["quay.io/openshift-release-dev/ocp-release"]}
+          ]'
+          echo "ClusterImagePolicy patched."
+
+          echo ""
+          echo "Verifying..."
+          oc get clusterimagepolicy openshift -o jsonpath='{.spec.scopes}'
+          echo ""
+          echo "Done. Unsigned nightly images from ocp-v4.0-art-dev and ocp-v5.0-art-dev are now allowed."

--- a/deploy/allow-unsigned-nightly-images/config.yaml
+++ b/deploy/allow-unsigned-nightly-images/config.yaml
@@ -1,0 +1,17 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values:
+      - "management-cluster"
+  - key: api.openshift.com/environment
+    operator: In
+    values:
+      - "staging"
+      - "integration"
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11873,6 +11873,122 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: allow-unsigned-nightly-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: allow-unsigned-nightly-images
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: allow-unsigned-nightly-images
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        - clusterimagepolicies
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: allow-unsigned-nightly-images
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: allow-unsigned-nightly-images
+      subjects:
+      - kind: ServiceAccount
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+        annotations:
+          kubernetes.io/description: Allow unsigned nightly OCP images on staging/int
+            MCs for HCP CI testing. 4.22 MCs enforce ClusterImagePolicy signature
+            verification which rejects unsigned nightly images used by HCP control
+            plane pods.
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: allow-unsigned-nightly-images
+          spec:
+            serviceAccountName: allow-unsigned-nightly-images
+            restartPolicy: Never
+            containers:
+            - name: allow-unsigned-nightly-images
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\necho \"============================================\"\
+                \necho \"Allow unsigned nightly images on staging MCs\"\necho \"============================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Add CVO override to unmanage ClusterImagePolicy\necho \"\
+                Adding CVO override for ClusterImagePolicy...\"\noc patch clusterversion\
+                \ version --type=merge -p '{\n  \"spec\": {\n    \"overrides\": [\n\
+                \      {\n        \"kind\": \"ClusterImagePolicy\",\n        \"group\"\
+                : \"config.openshift.io\",\n        \"name\": \"openshift\",\n   \
+                \     \"namespace\": \"\",\n        \"unmanaged\": true\n      }\n\
+                \    ]\n  }\n}'\necho \"CVO override added.\"\n\n# Step 2: Patch ClusterImagePolicy\
+                \ to only enforce signatures on released payloads\n# Remove ocp-v4.0-art-dev\
+                \ and ocp-v5.0-art-dev scopes (nightly images)\n# Keep ocp-release\
+                \ scope (signed released payloads)\necho \"Patching ClusterImagePolicy\
+                \ scopes...\"\noc patch clusterimagepolicy openshift --type=json -p\
+                \ '[\n  {\"op\": \"replace\", \"path\": \"/spec/scopes\", \"value\"\
+                : [\"quay.io/openshift-release-dev/ocp-release\"]}\n]'\necho \"ClusterImagePolicy\
+                \ patched.\"\n\necho \"\"\necho \"Verifying...\"\noc get clusterimagepolicy\
+                \ openshift -o jsonpath='{.spec.scopes}'\necho \"\"\necho \"Done.\
+                \ Unsigned nightly images from ocp-v4.0-art-dev and ocp-v5.0-art-dev\
+                \ are now allowed.\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: aws-ssm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11873,6 +11873,122 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: allow-unsigned-nightly-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: allow-unsigned-nightly-images
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: allow-unsigned-nightly-images
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        - clusterimagepolicies
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: allow-unsigned-nightly-images
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: allow-unsigned-nightly-images
+      subjects:
+      - kind: ServiceAccount
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+        annotations:
+          kubernetes.io/description: Allow unsigned nightly OCP images on staging/int
+            MCs for HCP CI testing. 4.22 MCs enforce ClusterImagePolicy signature
+            verification which rejects unsigned nightly images used by HCP control
+            plane pods.
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: allow-unsigned-nightly-images
+          spec:
+            serviceAccountName: allow-unsigned-nightly-images
+            restartPolicy: Never
+            containers:
+            - name: allow-unsigned-nightly-images
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\necho \"============================================\"\
+                \necho \"Allow unsigned nightly images on staging MCs\"\necho \"============================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Add CVO override to unmanage ClusterImagePolicy\necho \"\
+                Adding CVO override for ClusterImagePolicy...\"\noc patch clusterversion\
+                \ version --type=merge -p '{\n  \"spec\": {\n    \"overrides\": [\n\
+                \      {\n        \"kind\": \"ClusterImagePolicy\",\n        \"group\"\
+                : \"config.openshift.io\",\n        \"name\": \"openshift\",\n   \
+                \     \"namespace\": \"\",\n        \"unmanaged\": true\n      }\n\
+                \    ]\n  }\n}'\necho \"CVO override added.\"\n\n# Step 2: Patch ClusterImagePolicy\
+                \ to only enforce signatures on released payloads\n# Remove ocp-v4.0-art-dev\
+                \ and ocp-v5.0-art-dev scopes (nightly images)\n# Keep ocp-release\
+                \ scope (signed released payloads)\necho \"Patching ClusterImagePolicy\
+                \ scopes...\"\noc patch clusterimagepolicy openshift --type=json -p\
+                \ '[\n  {\"op\": \"replace\", \"path\": \"/spec/scopes\", \"value\"\
+                : [\"quay.io/openshift-release-dev/ocp-release\"]}\n]'\necho \"ClusterImagePolicy\
+                \ patched.\"\n\necho \"\"\necho \"Verifying...\"\noc get clusterimagepolicy\
+                \ openshift -o jsonpath='{.spec.scopes}'\necho \"\"\necho \"Done.\
+                \ Unsigned nightly images from ocp-v4.0-art-dev and ocp-v5.0-art-dev\
+                \ are now allowed.\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: aws-ssm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11873,6 +11873,122 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: allow-unsigned-nightly-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: allow-unsigned-nightly-images
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: allow-unsigned-nightly-images
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        - clusterimagepolicies
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: allow-unsigned-nightly-images
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: allow-unsigned-nightly-images
+      subjects:
+      - kind: ServiceAccount
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: allow-unsigned-nightly-images
+        namespace: allow-unsigned-nightly-images
+        annotations:
+          kubernetes.io/description: Allow unsigned nightly OCP images on staging/int
+            MCs for HCP CI testing. 4.22 MCs enforce ClusterImagePolicy signature
+            verification which rejects unsigned nightly images used by HCP control
+            plane pods.
+      spec:
+        backoffLimit: 3
+        activeDeadlineSeconds: 300
+        template:
+          metadata:
+            name: allow-unsigned-nightly-images
+          spec:
+            serviceAccountName: allow-unsigned-nightly-images
+            restartPolicy: Never
+            containers:
+            - name: allow-unsigned-nightly-images
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+              command:
+              - /bin/bash
+              - -c
+              - "#!/bin/bash\nset -euo pipefail\n\necho \"============================================\"\
+                \necho \"Allow unsigned nightly images on staging MCs\"\necho \"============================================\"\
+                \necho \"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\"\necho \"\"\n\n\
+                # Step 1: Add CVO override to unmanage ClusterImagePolicy\necho \"\
+                Adding CVO override for ClusterImagePolicy...\"\noc patch clusterversion\
+                \ version --type=merge -p '{\n  \"spec\": {\n    \"overrides\": [\n\
+                \      {\n        \"kind\": \"ClusterImagePolicy\",\n        \"group\"\
+                : \"config.openshift.io\",\n        \"name\": \"openshift\",\n   \
+                \     \"namespace\": \"\",\n        \"unmanaged\": true\n      }\n\
+                \    ]\n  }\n}'\necho \"CVO override added.\"\n\n# Step 2: Patch ClusterImagePolicy\
+                \ to only enforce signatures on released payloads\n# Remove ocp-v4.0-art-dev\
+                \ and ocp-v5.0-art-dev scopes (nightly images)\n# Keep ocp-release\
+                \ scope (signed released payloads)\necho \"Patching ClusterImagePolicy\
+                \ scopes...\"\noc patch clusterimagepolicy openshift --type=json -p\
+                \ '[\n  {\"op\": \"replace\", \"path\": \"/spec/scopes\", \"value\"\
+                : [\"quay.io/openshift-release-dev/ocp-release\"]}\n]'\necho \"ClusterImagePolicy\
+                \ patched.\"\n\necho \"\"\necho \"Verifying...\"\noc get clusterimagepolicy\
+                \ openshift -o jsonpath='{.spec.scopes}'\necho \"\"\necho \"Done.\
+                \ Unsigned nightly images from ocp-v4.0-art-dev and ocp-v5.0-art-dev\
+                \ are now allowed.\"\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: aws-ssm-agent
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
## Summary

- Add SelectorSyncSet job to remove ocp-v4.0-art-dev and ocp-v5.0-art-dev scopes from ClusterImagePolicy on staging/int management clusters
- Add CVO override to prevent CVO from reverting the change
- Scoped to staging/int MCs only (not production, not FedRAMP)

## Problem

OCP 4.22 introduced ClusterImagePolicy that enforces signature verification on all images from quay.io/openshift-release-dev/ocp-v4.0-art-dev. Nightly OCP images are intentionally unsigned. When staging MCs were upgraded to 4.22, the MC CRI-O started rejecting unsigned nightly images used by HCP control plane pods (cluster-api, control-plane-operator, etc.), causing SignatureValidationFailed / ImagePullBackOff.

This broke all HCP conformance and nightly CI jobs (5+ jobs at 0% pass rate since the MC upgrade).

## Evidence

Confirmed live on staging MC hs-mc-13vnfh7o0. After patching ClusterImagePolicy to remove the ocp-v4.0-art-dev scope, replacement pods pulled successfully and reached Running state.

## Fix

The job:
1. Adds a CVO override marking ClusterImagePolicy/openshift as unmanaged (prevents CVO from reverting)
2. Patches ClusterImagePolicy scopes to only enforce signatures on ocp-release (signed released payloads), allowing unsigned nightly images

## Testing

- Manually applied on 1 int MC + 3 staging MCs
- Verified: stuck ImagePullBackOff pods deleted, replacements pulled successfully
- Monitoring next HCP conformance job runs to validate end-to-end

Jira: https://redhat.atlassian.net/browse/ROSAENG-61768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment automation for temporarily allowing unsigned nightly images.
  * Configured the required permissions and secure service account for this process.
  * Added validation and retry controls to ensure the configuration is applied safely.
  * Enabled synchronization to staging and integration management clusters, excluding FedRAMP environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->