### PR TITLE
Restrict CMG to critical/high alerts only.

### DIFF
--- a/deploy/sre-prometheus-must-gather/100-create-must-gather.PrometheusRule.yaml
+++ b/deploy/sre-prometheus-must-gather/100-create-must-gather.PrometheusRule.yaml
@@ -12,7 +12,7 @@ spec:
       rules:
         - alert: CreateMustGather
           expr: |
-            max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"}) > 0
+            max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none|warning",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"}) > 0
             and on() absent(cluster_version{type="updating"})
             and on() (time() - max(cluster_version{type="completed"}) > 14400)
           for: 15m
@@ -21,7 +21,7 @@ spec:
             namespace: openshift-monitoring
             route_to_cad: "true"
           annotations:
-            message: Create a must-gather for a non-silenced firing alert in a managed namespace
+            message: Create a must-gather for a non-silenced firing critical/error alert in a managed namespace
             runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
             summary: 'This alert is a trigger for CAD to create a must-gather.'
-            description: This alert fires when a non-silenced alert is firing in a managed namespace. This alert is meant to trigger configuration-anomaly-detection to create a must-gather
+            description: This alert fires when a non-silenced critical or error alert is firing in a managed namespace. This alert is meant to trigger configuration-anomaly-detection to create a must-gather

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45955,7 +45955,7 @@ objects:
         - name: sre-create-must-gather
           rules:
           - alert: CreateMustGather
-            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none|warning",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
               > 0
 
               and on() absent(cluster_version{type="updating"})
@@ -45969,13 +45969,13 @@ objects:
               namespace: openshift-monitoring
               route_to_cad: 'true'
             annotations:
-              message: Create a must-gather for a non-silenced firing alert in a managed
-                namespace
+              message: Create a must-gather for a non-silenced firing critical/error
+                alert in a managed namespace
               runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
               summary: This alert is a trigger for CAD to create a must-gather.
-              description: This alert fires when a non-silenced alert is firing in
-                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
-                to create a must-gather
+              description: This alert fires when a non-silenced critical or error
+                alert is firing in a managed namespace. This alert is meant to trigger
+                configuration-anomaly-detection to create a must-gather
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45955,7 +45955,7 @@ objects:
         - name: sre-create-must-gather
           rules:
           - alert: CreateMustGather
-            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none|warning",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
               > 0
 
               and on() absent(cluster_version{type="updating"})
@@ -45969,13 +45969,13 @@ objects:
               namespace: openshift-monitoring
               route_to_cad: 'true'
             annotations:
-              message: Create a must-gather for a non-silenced firing alert in a managed
-                namespace
+              message: Create a must-gather for a non-silenced firing critical/error
+                alert in a managed namespace
               runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
               summary: This alert is a trigger for CAD to create a must-gather.
-              description: This alert fires when a non-silenced alert is firing in
-                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
-                to create a must-gather
+              description: This alert fires when a non-silenced critical or error
+                alert is firing in a managed namespace. This alert is meant to trigger
+                configuration-anomaly-detection to create a must-gather
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45955,7 +45955,7 @@ objects:
         - name: sre-create-must-gather
           rules:
           - alert: CreateMustGather
-            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none|warning",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn|CsvAbnormalFailedOver2Min|LokiTenantRateLimit|PrometheusRemoteStorageFailures"})
               > 0
 
               and on() absent(cluster_version{type="updating"})
@@ -45969,13 +45969,13 @@ objects:
               namespace: openshift-monitoring
               route_to_cad: 'true'
             annotations:
-              message: Create a must-gather for a non-silenced firing alert in a managed
-                namespace
+              message: Create a must-gather for a non-silenced firing critical/error
+                alert in a managed namespace
               runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
               summary: This alert is a trigger for CAD to create a must-gather.
-              description: This alert fires when a non-silenced alert is firing in
-                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
-                to create a must-gather
+              description: This alert fires when a non-silenced critical or error
+                alert is firing in a managed namespace. This alert is meant to trigger
+                configuration-anomaly-detection to create a must-gather
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Add warning to the exclusion filter so CMG only fires for critical and high alerts.

https://redhat.atlassian.net/browse/ROSAENG-65338

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alert filtering to exclude warning-severity alerts.
  * Clarified alert messages and descriptions to indicate they apply to non-silenced, firing critical and error alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->