### PR TITLE
[ROSAENG-61272] Migrate PassRole IAM with conditions for 4.22 to restrict attack surface

### DIFF
--- a/resources/sts/4.22/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/resources/sts/4.22/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -25,10 +25,27 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
-        "iam:CreateServiceLinkedRole",
-        "iam:PassRole"
+        "iam:CreateServiceLinkedRole"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "PassRoleToNodes",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "arn:*:iam::*:role/*-ControlPlane-Role",
+        "arn:*:iam::*:role/*-Worker-Role"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+            "ec2.amazonaws.com"
+          ]
+        }
+      }
     },
     {
       "Effect": "Allow",

--- a/resources/sts/4.22/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/resources/sts/4.22/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -35,10 +35,7 @@
       "Action": [
         "iam:PassRole"
       ],
-      "Resource": [
-        "arn:*:iam::*:role/*-ControlPlane-Role",
-        "arn:*:iam::*:role/*-Worker-Role"
-      ],
+      "Resource": "*",
       "Condition": {
         "StringEquals": {
           "iam:PassedToService": [

--- a/resources/sts/4.22/sts_installer_core_permission_boundary_policy.json
+++ b/resources/sts/4.22/sts_installer_core_permission_boundary_policy.json
@@ -104,7 +104,6 @@
 		    "iam:ListRoles",
 		    "iam:ListUserPolicies",
 		    "iam:ListUsers",
-		    "iam:PassRole",
 		    "iam:RemoveRoleFromInstanceProfile",
 		    "iam:SimulatePrincipalPolicy",
 		    "iam:TagRole",
@@ -173,6 +172,24 @@
             ],
             "Resource": "*"
         },
+		{
+      		"Sid": "PassRoleToNodes",
+			"Effect": "Allow",
+      		"Action": [
+        		"iam:PassRole"
+      		],
+      		"Resource": [
+				"arn:*:iam::*:role/*-ControlPlane-Role",
+        		"arn:*:iam::*:role/*-Worker-Role"
+      		],
+      		"Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": [
+                        "ec2.amazonaws.com"
+                    ]
+                }
+            }
+    	},
         {
             "Effect": "Allow",
             "Action": [

--- a/resources/sts/4.22/sts_installer_core_permission_boundary_policy.json
+++ b/resources/sts/4.22/sts_installer_core_permission_boundary_policy.json
@@ -178,10 +178,7 @@
       		"Action": [
         		"iam:PassRole"
       		],
-      		"Resource": [
-				"arn:*:iam::*:role/*-ControlPlane-Role",
-        		"arn:*:iam::*:role/*-Worker-Role"
-      		],
+      		"Resource": "*",
       		"Condition": {
                 "StringEquals": {
                     "iam:PassedToService": [

--- a/resources/sts/4.22/sts_installer_permission_policy.json
+++ b/resources/sts/4.22/sts_installer_permission_policy.json
@@ -131,7 +131,6 @@
                 "iam:ListRoles",
                 "iam:ListUserPolicies",
                 "iam:ListUsers",
-                "iam:PassRole",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:SimulatePrincipalPolicy",
                 "iam:TagRole",
@@ -197,6 +196,24 @@
                 "cloudwatch:GetMetricData"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "PassRoleToNodes",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:*:iam::*:role/*-ControlPlane-Role",
+                "arn:*:iam::*:role/*-Worker-Role"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": [
+                        "ec2.amazonaws.com"
+                    ]
+                }
+            }
         },
         {
             "Effect": "Allow",

--- a/resources/sts/4.22/sts_installer_permission_policy.json
+++ b/resources/sts/4.22/sts_installer_permission_policy.json
@@ -203,10 +203,7 @@
             "Action": [
                 "iam:PassRole"
             ],
-            "Resource": [
-                "arn:*:iam::*:role/*-ControlPlane-Role",
-                "arn:*:iam::*:role/*-Worker-Role"
-            ],
+            "Resource": "*",
             "Condition": {
                 "StringEquals": {
                     "iam:PassedToService": [


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Bug

### What this PR does / why we need it?
Migrate PassRole IAM with conditions for 4.22 to restrict attack surface

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [ROSAENG-61272](https://redhat.atlassian.net/browse/ROSAENG-61272)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Restricted IAM role-passing permissions to roles passed to Amazon EC2.
  * Removed broad, unconditional `iam:PassRole` permissions from installer and machine API policies.
  * Preserved permissions required to create AWS service-linked roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->