### PR TITLE
ROSAENG-65392: Suppress CannotRetrieveUpdatesSRE for Y+1 channel

### DIFF
--- a/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
@@ -30,7 +30,7 @@ spec:
         expr: '
             (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600
           and ignoring(condition, name, reason)
-            (cluster_operator_conditions{name="version",condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"})
+            (cluster_operator_conditions{name="version",condition="RetrievedUpdates", endpoint="metrics", reason!~"NoChannel|VersionNotFound"})
           and on(instance, job, namespace, pod, service)
             (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"})
           '

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45424,8 +45424,8 @@ objects:
               summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
-              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
-              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+              endpoint="metrics", reason!~"NoChannel|VersionNotFound"}) and on(instance,
+              job, namespace, pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
             for: 2h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45424,8 +45424,8 @@ objects:
               summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
-              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
-              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+              endpoint="metrics", reason!~"NoChannel|VersionNotFound"}) and on(instance,
+              job, namespace, pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
             for: 2h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45424,8 +45424,8 @@ objects:
               summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
-              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
-              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+              endpoint="metrics", reason!~"NoChannel|VersionNotFound"}) and on(instance,
+              job, namespace, pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
             for: 2h
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Exclude reason=VersionNotFound from the CannotRetrieveUpdatesSRE alert to prevent false positives when customers set a Y+1 channel (e.g. stable-4.20 on a 4.19.x cluster) before the current version has been promoted to that channel's graph.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:
Before
<img width="1162" height="759" alt="Screenshot 2026-08-17 at 10 18 55 AM" src="https://github.com/user-attachments/assets/b19df0eb-2b8a-405f-95e5-69425f3e7e04" />
After
<img width="1177" height="523" alt="Screenshot 2026-08-17 at 10 19 01 AM" src="https://github.com/user-attachments/assets/99cd050c-3b32-48ac-8151-d0c606ea1683" />


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update retrieval monitoring by excluding both `NoChannel` and `VersionNotFound` conditions from failure alerts.
  * Reduced false-positive alerts for expected update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->