### PR TITLE
ROSAENG-63029 - Send automated servicelog for not-ready EC2NodeClass 

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/ec2nodeclass-not-ready.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/ec2nodeclass-not-ready.yaml
@@ -1,0 +1,27 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedFleetNotification
+metadata:
+  name: ec2nodeclass-not-ready
+  namespace: openshift-ocm-agent-operator
+spec:
+  fleetNotification:
+    name: ec2nodeclass-not-ready
+    severity: Warning
+    summary: "Action required: AutoNode (Karpenter) OpenShiftEC2NodeClass not ready"
+    logType: "Cluster Configuration"
+    notificationMessage: |-
+      Red Hat has identified one or more OpenShiftEC2NodeClass resources on your cluster are not ready. This can cause NodePools that reference these resources to not become ready, Karpenter to not provision nodes and workloads to become unavailable.
+
+      Common causes include:
+      - Missing or incorrect subnet tags on your VPC subnets
+      - Missing security group tags
+      - Deleted worker instance profile
+      - IAM role permission issues
+
+      For more information, please refer to: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+
+      If you need assistance, please open a support case.
+    resendWait: 24
+    limitedSupport: false
+    references:
+      - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-ec2nodeclass-not-ready.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-ec2nodeclass-not-ready.PrometheusRule.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.rhobs/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: ec2nodeclass-not-ready
+    role: alert-rules
+  name: ec2nodeclass-not-ready
+  namespace: openshift-observability-rhobs
+spec:
+  groups:
+    - name: ec2nodeclass-not-ready
+      interval: 60s
+      rules:
+        - alert: OpenshiftEC2NodeClassNotReadyFleetNotification
+          annotations:
+            description: "OpenshiftEC2NodeClass {{ $labels.name }} has been in a non-Ready state for more than 5 minutes."
+            runbook_url: https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/OpenshiftEC2NodeClassNotReady.md
+            summary: "OpenshiftEC2NodeClass not ready."
+          expr: (operator_ec2nodeclass_status_condition_current_status_seconds{type="Ready", status!="True"}) unless on (_id) sre:hcp:alerts_suppressed
+          for: 5m
+          labels:
+            severity: info
+            send_managed_notification: "true"
+            managed_notification_template: ec2nodeclass-not-ready
+            namespace: "{{ $labels.namespace }}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32310,6 +32310,43 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: ec2nodeclass-not-ready
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: ec2nodeclass-not-ready
+          severity: Warning
+          summary: 'Action required: AutoNode (Karpenter) OpenShiftEC2NodeClass not
+            ready'
+          logType: Cluster Configuration
+          notificationMessage: 'Red Hat has identified one or more OpenShiftEC2NodeClass
+            resources on your cluster are not ready. This can cause NodePools that
+            reference these resources to not become ready, Karpenter to not provision
+            nodes and workloads to become unavailable.
+
+
+            Common causes include:
+
+            - Missing or incorrect subnet tags on your VPC subnets
+
+            - Missing security group tags
+
+            - Deleted worker instance profile
+
+            - IAM role permission issues
+
+
+            For more information, please refer to: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          limitedSupport: false
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure-spot
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48552,6 +48589,33 @@ objects:
               severity: warning
               send_managed_notification: 'true'
               managed_notification_template: autonode-iam-misconfiguration
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: ec2nodeclass-not-ready
+          role: alert-rules
+        name: ec2nodeclass-not-ready
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: ec2nodeclass-not-ready
+          interval: 60s
+          rules:
+          - alert: OpenshiftEC2NodeClassNotReadyFleetNotification
+            annotations:
+              description: OpenshiftEC2NodeClass {{ $labels.name }} has been in a
+                non-Ready state for more than 5 minutes.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/OpenshiftEC2NodeClassNotReady.md
+              summary: OpenshiftEC2NodeClass not ready.
+            expr: (operator_ec2nodeclass_status_condition_current_status_seconds{type="Ready",
+              status!="True"}) unless on (_id) sre:hcp:alerts_suppressed
+            for: 5m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: ec2nodeclass-not-ready
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32310,6 +32310,43 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: ec2nodeclass-not-ready
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: ec2nodeclass-not-ready
+          severity: Warning
+          summary: 'Action required: AutoNode (Karpenter) OpenShiftEC2NodeClass not
+            ready'
+          logType: Cluster Configuration
+          notificationMessage: 'Red Hat has identified one or more OpenShiftEC2NodeClass
+            resources on your cluster are not ready. This can cause NodePools that
+            reference these resources to not become ready, Karpenter to not provision
+            nodes and workloads to become unavailable.
+
+
+            Common causes include:
+
+            - Missing or incorrect subnet tags on your VPC subnets
+
+            - Missing security group tags
+
+            - Deleted worker instance profile
+
+            - IAM role permission issues
+
+
+            For more information, please refer to: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          limitedSupport: false
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure-spot
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48552,6 +48589,33 @@ objects:
               severity: warning
               send_managed_notification: 'true'
               managed_notification_template: autonode-iam-misconfiguration
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: ec2nodeclass-not-ready
+          role: alert-rules
+        name: ec2nodeclass-not-ready
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: ec2nodeclass-not-ready
+          interval: 60s
+          rules:
+          - alert: OpenshiftEC2NodeClassNotReadyFleetNotification
+            annotations:
+              description: OpenshiftEC2NodeClass {{ $labels.name }} has been in a
+                non-Ready state for more than 5 minutes.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/OpenshiftEC2NodeClassNotReady.md
+              summary: OpenshiftEC2NodeClass not ready.
+            expr: (operator_ec2nodeclass_status_condition_current_status_seconds{type="Ready",
+              status!="True"}) unless on (_id) sre:hcp:alerts_suppressed
+            for: 5m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: ec2nodeclass-not-ready
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32310,6 +32310,43 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: ec2nodeclass-not-ready
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: ec2nodeclass-not-ready
+          severity: Warning
+          summary: 'Action required: AutoNode (Karpenter) OpenShiftEC2NodeClass not
+            ready'
+          logType: Cluster Configuration
+          notificationMessage: 'Red Hat has identified one or more OpenShiftEC2NodeClass
+            resources on your cluster are not ready. This can cause NodePools that
+            reference these resources to not become ready, Karpenter to not provision
+            nodes and workloads to become unavailable.
+
+
+            Common causes include:
+
+            - Missing or incorrect subnet tags on your VPC subnets
+
+            - Missing security group tags
+
+            - Deleted worker instance profile
+
+            - IAM role permission issues
+
+
+            For more information, please refer to: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+
+
+            If you need assistance, please open a support case.'
+          resendWait: 24
+          limitedSupport: false
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: nodepool-provisioning-failure-spot
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48552,6 +48589,33 @@ objects:
               severity: warning
               send_managed_notification: 'true'
               managed_notification_template: autonode-iam-misconfiguration
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: ec2nodeclass-not-ready
+          role: alert-rules
+        name: ec2nodeclass-not-ready
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: ec2nodeclass-not-ready
+          interval: 60s
+          rules:
+          - alert: OpenshiftEC2NodeClassNotReadyFleetNotification
+            annotations:
+              description: OpenshiftEC2NodeClass {{ $labels.name }} has been in a
+                non-Ready state for more than 5 minutes.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/OpenshiftEC2NodeClassNotReady.md
+              summary: OpenshiftEC2NodeClass not ready.
+            expr: (operator_ec2nodeclass_status_condition_current_status_seconds{type="Ready",
+              status!="True"}) unless on (_id) sre:hcp:alerts_suppressed
+            for: 5m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: ec2nodeclass-not-ready
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Adds an ocm-agent managed fleet notification to automatically send a service log to customers when an `OpenshiftEC2NodeClass` is not ready for 5+ minutes on ROSA HCP clusters. This replaces the need for SRE manual investigation via PagerDuty/CAD — the service log is sent directly via ocm-agent-fleet on the management cluster.

**Changes:**
- **PrometheusRule** (`100-ec2nodeclass-not-ready.PrometheusRule.yaml`): Fires `OpenshiftEC2NodeClassNotReadyFleetNotification` using the existing `operator_ec2nodeclass_status_condition_current_status_seconds` metric, routed to ocm-agent via `send_managed_notification: "true"`
- **ManagedFleetNotification** (`ec2nodeclass-not-ready.yaml`): Generic service log covering common causes (missing subnet tags, missing security group tags, AMI unavailable, deleted instance profile, IAM role issues) with troubleshooting steps and documentation link

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/ROSAENG-63029

### Special notes for your reviewer:

- The existing `OpenshiftEC2NodeClassNotReady` PD alert in RHOBS (`RHOBS/configuration/resources/tenant-rules/hcp/karpenter.yaml`) should be removed in a separate PR once this is deployed, to stop PD routing for this alert.
- The service log is generic (covers all common causes) rather than differentiating between default and custom NodeClasses, since ocm-agent does not have access to inspect the CRD spec on the hosted cluster.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added notifications when an OpenShift EC2 node class is not ready.
  - Added a monitoring alert for node classes that remain non-ready for more than five minutes.
  - Notifications include warning severity, support guidance, resend timing, and documentation references.
  - Alerts include informational status, descriptive details, summaries, runbook information, and namespace metadata.
  - Suppressed alerts are excluded from monitoring notifications.
  - These updates improve visibility into node class readiness issues and provide guidance for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->