### PR TITLE
ROSAENG-15535: send automated SL for AutoNode IAM misconfiguration

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/autonode-iam-misconfiguration.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/autonode-iam-misconfiguration.yaml
@@ -1,0 +1,26 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedFleetNotification
+metadata:
+  name: autonode-iam-misconfiguration
+  namespace: openshift-ocm-agent-operator
+spec:
+  fleetNotification:
+    name: autonode-iam-misconfiguration
+    summary: Karpenter IAM role misconfiguration detected
+    notificationMessage: |-
+      Your ROSA cluster's Karpenter (AutoNode) is unable to launch EC2 instances due to an IAM role or instance profile misconfiguration. This prevents new nodes from being provisioned and may impact your workloads.
+
+      Common causes include:
+      - Missing or incorrect trust policy on the node IAM role
+      - Missing required managed policies (e.g., the Karpenter managed policy)
+      - Permissions boundary blocking required actions
+      - Instance profile does not exist or ARN is incorrect
+
+      Please verify your IAM role configuration matches the expected setup described in the ROSA documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+
+      If you need assistance, please open a support case.
+    references:
+      - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+    resendWait: 24
+    severity: Warning
+    limitedSupport: false

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-autonode-iam-misconfiguration.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-autonode-iam-misconfiguration.PrometheusRule.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: monitoring.rhobs/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: autonode-iam-misconfiguration
+    role: alert-rules
+  name: autonode-iam-misconfiguration
+  namespace: openshift-observability-rhobs
+spec:
+  groups:
+    - name: AutoNodeIAMMisconfigurationFleetNotification
+      interval: 60s
+      rules:
+        - alert: AutoNodeIAMMisconfigurationSRE
+          annotations:
+            description: "AutoNode encountering IAM-related errors for cluster {{ $labels._id }}, indicating a misconfigured IAM role or instance profile."
+            summary: "AutoNode IAM role misconfiguration detected"
+          expr: sum by (_id, namespace) (operator_nodeclaim_status_condition_count{reason=~"Unauthorized|InstanceProfileNameInvalid|SpotSLRCreationFailed|AMIAuthorizationFailure"}) > 0 unless on (_id) sre:hcp:alerts_suppressed
+          for: 15m
+          labels:
+            severity: warning
+            send_managed_notification: "true"
+            managed_notification_template: autonode-iam-misconfiguration
+            namespace: "{{ $labels.namespace }}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32238,6 +32238,41 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: autonode-iam-misconfiguration
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: autonode-iam-misconfiguration
+          summary: Karpenter IAM role misconfiguration detected
+          notificationMessage: 'Your ROSA cluster''s Karpenter (AutoNode) is unable
+            to launch EC2 instances due to an IAM role or instance profile misconfiguration.
+            This prevents new nodes from being provisioned and may impact your workloads.
+
+
+            Common causes include:
+
+            - Missing or incorrect trust policy on the node IAM role
+
+            - Missing required managed policies (e.g., the Karpenter managed policy)
+
+            - Permissions boundary blocking required actions
+
+            - Instance profile does not exist or ARN is incorrect
+
+
+            Please verify your IAM role configuration matches the expected setup described
+            in the ROSA documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+
+
+            If you need assistance, please open a support case.'
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: customer-monitoring-operator-down
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48460,6 +48495,32 @@ objects:
               severity: info
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: autonode-iam-misconfiguration
+          role: alert-rules
+        name: autonode-iam-misconfiguration
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: AutoNodeIAMMisconfigurationFleetNotification
+          interval: 60s
+          rules:
+          - alert: AutoNodeIAMMisconfigurationSRE
+            annotations:
+              description: AutoNode encountering IAM-related errors for cluster {{
+                $labels._id }}, indicating a misconfigured IAM role or instance profile.
+              summary: AutoNode IAM role misconfiguration detected
+            expr: sum by (_id, namespace) (operator_nodeclaim_status_condition_count{reason=~"Unauthorized|InstanceProfileNameInvalid|SpotSLRCreationFailed|AMIAuthorizationFailure"})
+              > 0 unless on (_id) sre:hcp:alerts_suppressed
+            for: 15m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: autonode-iam-misconfiguration
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32238,6 +32238,41 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: autonode-iam-misconfiguration
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: autonode-iam-misconfiguration
+          summary: Karpenter IAM role misconfiguration detected
+          notificationMessage: 'Your ROSA cluster''s Karpenter (AutoNode) is unable
+            to launch EC2 instances due to an IAM role or instance profile misconfiguration.
+            This prevents new nodes from being provisioned and may impact your workloads.
+
+
+            Common causes include:
+
+            - Missing or incorrect trust policy on the node IAM role
+
+            - Missing required managed policies (e.g., the Karpenter managed policy)
+
+            - Permissions boundary blocking required actions
+
+            - Instance profile does not exist or ARN is incorrect
+
+
+            Please verify your IAM role configuration matches the expected setup described
+            in the ROSA documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+
+
+            If you need assistance, please open a support case.'
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: customer-monitoring-operator-down
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48460,6 +48495,32 @@ objects:
               severity: info
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: autonode-iam-misconfiguration
+          role: alert-rules
+        name: autonode-iam-misconfiguration
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: AutoNodeIAMMisconfigurationFleetNotification
+          interval: 60s
+          rules:
+          - alert: AutoNodeIAMMisconfigurationSRE
+            annotations:
+              description: AutoNode encountering IAM-related errors for cluster {{
+                $labels._id }}, indicating a misconfigured IAM role or instance profile.
+              summary: AutoNode IAM role misconfiguration detected
+            expr: sum by (_id, namespace) (operator_nodeclaim_status_condition_count{reason=~"Unauthorized|InstanceProfileNameInvalid|SpotSLRCreationFailed|AMIAuthorizationFailure"})
+              > 0 unless on (_id) sre:hcp:alerts_suppressed
+            for: 15m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: autonode-iam-misconfiguration
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32238,6 +32238,41 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedFleetNotification
       metadata:
+        name: autonode-iam-misconfiguration
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: autonode-iam-misconfiguration
+          summary: Karpenter IAM role misconfiguration detected
+          notificationMessage: 'Your ROSA cluster''s Karpenter (AutoNode) is unable
+            to launch EC2 instances due to an IAM role or instance profile misconfiguration.
+            This prevents new nodes from being provisioned and may impact your workloads.
+
+
+            Common causes include:
+
+            - Missing or incorrect trust policy on the node IAM role
+
+            - Missing required managed policies (e.g., the Karpenter managed policy)
+
+            - Permissions boundary blocking required actions
+
+            - Instance profile does not exist or ARN is incorrect
+
+
+            Please verify your IAM role configuration matches the expected setup described
+            in the ROSA documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+
+
+            If you need assistance, please open a support case.'
+          references:
+          - https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-red-hat-build-of-karpenter#rosa-nodes-autonode-managing-setup_rosa-autonode-setup
+          resendWait: 24
+          severity: Warning
+          limitedSupport: false
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
         name: customer-monitoring-operator-down
         namespace: openshift-ocm-agent-operator
       spec:
@@ -48460,6 +48495,32 @@ objects:
               severity: info
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: autonode-iam-misconfiguration
+          role: alert-rules
+        name: autonode-iam-misconfiguration
+        namespace: openshift-observability-rhobs
+      spec:
+        groups:
+        - name: AutoNodeIAMMisconfigurationFleetNotification
+          interval: 60s
+          rules:
+          - alert: AutoNodeIAMMisconfigurationSRE
+            annotations:
+              description: AutoNode encountering IAM-related errors for cluster {{
+                $labels._id }}, indicating a misconfigured IAM role or instance profile.
+              summary: AutoNode IAM role misconfiguration detected
+            expr: sum by (_id, namespace) (operator_nodeclaim_status_condition_count{reason=~"Unauthorized|InstanceProfileNameInvalid|SpotSLRCreationFailed|AMIAuthorizationFailure"})
+              > 0 unless on (_id) sre:hcp:alerts_suppressed
+            for: 15m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: autonode-iam-misconfiguration
               namespace: '{{ $labels.namespace }}'
     - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / why we need it?

This PR adds an automated Service Log for issues with IAM configuration that prevents AutoNode (Karpenter) from provisioning new EC2 instances.

The underlying metric (`operator_nodeclaim_status_condition_count`) is provided by the AWS implementation of Karpenter ([docs](https://github.com/aws/karpenter-provider-aws/blob/main/website/content/en/docs/reference/metrics.md?plain=1#L73)), which should be a good choice for this, NodeClaim launch failures get recorded in a `reason` label (set [here](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/errors/errors.go#L224
)) that we can filter on. I've filtered on values that are associated with IAM permission issues (and invalid instance profile name).

This metric is currently scraped by OBO prometheus, but not forwarded to RHOBS.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://redhat.atlassian.net/browse/ROSAENG-15535

### Special notes for your reviewer:

- From pre-testing in staging, this does not catch instances where the IAM configuration is bad when the karpenter operator starts, karpenter gets stuck in a crash loop in that case and does not provide reason-specific error metrics.
- We don't currently ship this metric to RHOBS, so its hard to conclusively check for previous cases where this would fire, but spot checking a few MCs, it doesnt appear to be noisy.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for AutoNode IAM configuration issues that can prevent instance launches.
  * Introduced warning notifications with remediation guidance, documentation links, severity details, and support information.
  * Alerts are raised after 15 minutes and automatically exclude clusters where notifications have been suppressed.
  * Notifications include clear troubleshooting steps to help identify and resolve configuration problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->