### PR TITLE
ROSAENG-3773: Migrate ACM PlacementRule resources to Placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ generated/
 .DS_Store
 .vscode/
 .idea/
+
+# PolicyGenerator binary downloaded by make
+.bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR ${REPO_PATH}
 
 # Upgrade pip and install necessasry packages
 RUN pip install --disable-pip-version-check oyaml
-ADD --chown=default https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
+ADD --chown=default https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.17.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
 RUN chmod +x /opt/app-root/bin/PolicyGenerator
 
 # Make

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -15,4 +15,4 @@ USER default
 
 RUN pip install --disable-pip-version-check oyaml
 
-ADD --chmod=755 https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.12.4/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
+ADD --chmod=755 https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.17.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,15 @@ generate-hive-templates: generate-oauth-templates
 		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}; scripts/add-annotations-tolerations.py";\
 		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; ${GEN_TEMPLATE}"; \
 	else \
-		${GEN_POLICY_CONFIG};\
-		${GEN_POLICY_CONFIG_SP};\
-		${GEN_POLICY};\
-		${GEN_CMO_CONFIG}; \
-		scripts/add-annotations-tolerations.py;\
+		mkdir -p .bin && \
+		curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output .bin/PolicyGenerator && \
+		chmod +x .bin/PolicyGenerator && \
+		export PATH="$$(pwd)/.bin:$$PATH" && \
+		${GEN_POLICY_CONFIG} && \
+		${GEN_POLICY_CONFIG_SP} && \
+		${GEN_POLICY} && \
+		${GEN_CMO_CONFIG} && \
+		scripts/add-annotations-tolerations.py && \
 		${GEN_TEMPLATE}; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ $(error CHECK_SSS_CONFLICTS is not set; check project.mk file)
 endif
 
 POLICYGEN_VERSION=v1.17.1
+BOILERPLATE_REPO_RAW=https://raw.githubusercontent.com/openshift/boilerplate/master
 
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
@@ -61,7 +62,15 @@ OC := $(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) quay.io/openshift/origin-cl
 endif
 
 .PHONY: default
-default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates
+default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates sync-owners-aliases
+
+.PHONY: sync-owners-aliases
+sync-owners-aliases:
+	tmpfile=$$(mktemp OWNERS_ALIASES.XXXXXX); \
+	trap 'rm -f "$$tmpfile"' EXIT; \
+	curl -fsSL --connect-timeout 10 --max-time 30 $(BOILERPLATE_REPO_RAW)/OWNERS_ALIASES -o "$$tmpfile" && \
+	chmod 0644 "$$tmpfile" && \
+	mv "$$tmpfile" OWNERS_ALIASES
 
 .PHONY: generate-oauth-templates
 generate-oauth-templates:
@@ -80,18 +89,14 @@ generate-rosa-brand-logo:
 .PHONY: generate-hive-templates
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P` && pip install --disable-pip-version-check oyaml && curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator && chmod +x /opt/app-root/bin/PolicyGenerator && ${GEN_POLICY_CONFIG} && ${GEN_POLICY_CONFIG_SP} && ${GEN_POLICY} && ${GEN_CMO_CONFIG} && scripts/add-annotations-tolerations.py" && \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P` && pip install --disable-pip-version-check oyaml && ${GEN_TEMPLATE}"; \
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}; scripts/add-annotations-tolerations.py";\
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; ${GEN_TEMPLATE}"; \
 	else \
-		mkdir -p .bin && \
-		curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output .bin/PolicyGenerator && \
-		chmod +x .bin/PolicyGenerator && \
-		export PATH="$$(pwd)/.bin:$$PATH" && \
-		${GEN_POLICY_CONFIG} && \
-		${GEN_POLICY_CONFIG_SP} && \
-		${GEN_POLICY} && \
-		${GEN_CMO_CONFIG} && \
-		scripts/add-annotations-tolerations.py && \
+		${GEN_POLICY_CONFIG};\
+		${GEN_POLICY_CONFIG_SP};\
+		${GEN_POLICY};\
+		${GEN_CMO_CONFIG}; \
+		scripts/add-annotations-tolerations.py;\
 		${GEN_TEMPLATE}; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ ifndef CHECK_SSS_CONFLICTS
 $(error CHECK_SSS_CONFLICTS is not set; check project.mk file)
 endif
 
-POLICYGEN_VERSION=v1.12.4
-BOILERPLATE_REPO_RAW=https://raw.githubusercontent.com/openshift/boilerplate/master
+POLICYGEN_VERSION=v1.17.1
 
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
@@ -62,15 +61,7 @@ OC := $(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) quay.io/openshift/origin-cl
 endif
 
 .PHONY: default
-default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates sync-owners-aliases
-
-.PHONY: sync-owners-aliases
-sync-owners-aliases:
-	tmpfile=$$(mktemp OWNERS_ALIASES.XXXXXX); \
-	trap 'rm -f "$$tmpfile"' EXIT; \
-	curl -fsSL --connect-timeout 10 --max-time 30 $(BOILERPLATE_REPO_RAW)/OWNERS_ALIASES -o "$$tmpfile" && \
-	chmod 0644 "$$tmpfile" && \
-	mv "$$tmpfile" OWNERS_ALIASES
+default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates
 
 .PHONY: generate-oauth-templates
 generate-oauth-templates:
@@ -89,14 +80,19 @@ generate-rosa-brand-logo:
 .PHONY: generate-hive-templates
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}";\
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; ${GEN_TEMPLATE}"; \
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P` && pip install --disable-pip-version-check oyaml && curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator && chmod +x /opt/app-root/bin/PolicyGenerator && ${GEN_POLICY_CONFIG} && ${GEN_POLICY_CONFIG_SP} && ${GEN_POLICY} && ${GEN_CMO_CONFIG} && scripts/add-annotations-tolerations.py" && \
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P` && pip install --disable-pip-version-check oyaml && ${GEN_TEMPLATE}"; \
 	else \
-		${GEN_POLICY_CONFIG};\
-		${GEN_POLICY_CONFIG_SP};\
-		${GEN_POLICY};\
+		mkdir -p .bin && \
+		curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output .bin/PolicyGenerator && \
+		chmod +x .bin/PolicyGenerator && \
+		export PATH="$$(pwd)/.bin:$$PATH" && \
+		${GEN_POLICY_CONFIG} && \
+		${GEN_POLICY_CONFIG_SP} && \
+		${GEN_POLICY} && \
+		${GEN_CMO_CONFIG} && \
+		scripts/add-annotations-tolerations.py && \
 		${GEN_TEMPLATE}; \
-		${GEN_CMO_CONFIG}; \
 	fi
 
 .PHONY: enforce-backplane-rules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the action will create a new commit with the generated files.
 To add an ACM (Governance) Policy
 - If the manifest of the object you want to convert to policy already exists in `deploy` : in the object config.yaml, add a field `policy: `destination: "acm-policies"` (example: https://github.com/openshift/managed-cluster-config/blob/master/deploy/backplane/cee/config.yaml) 
 - If the manifest of the object does not exist: add your manifests with a config.yaml file. If you only want this object to be deployed as Policy, see [this example](https://github.com/openshift/managed-cluster-config/tree/bad140663d088cbce06edaf2527f69651db5a80b/deploy/hs-mgmt-route-monitor-operator)
+- Policies are placed with `Placement` (`cluster.open-cluster-management.io/v1beta1`). A `Placement` only considers clusters from `ManagedClusterSet`s bound into its own namespace, so `deploy/acm-policies` and `deploy/rosa-oauth-templates-policies` each carry a `ManagedClusterSetBinding` for the `global` set. A new policy namespace needs its own binding, or its placements will never be satisfied.
 
 `make` will look for `config.yaml` files, runs it with the PolicyGenerator binary and save the output to `generated_deploy/acm-policies` directory. `make` will then automatically
 add the policy as a new SelectorySyncSet.

--- a/deploy/acm-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
+++ b/deploy/acm-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-acm-policies
+spec:
+  clusterSet: global

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-acs
     namespace: openshift-acm-policies
@@ -874,18 +875,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-acs
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: api.openshift.com/addon-acs-fleetshard
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: api.openshift.com/addon-acs-fleetshard
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -893,8 +901,8 @@ metadata:
     name: binding-backplane-acs
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-acs
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -878,7 +878,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-acs
+    name: backplane-acs-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -898,12 +898,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-acs
+    name: backplane-acs-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-acs
+    name: backplane-acs-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-ai-agent-sp
     namespace: openshift-acm-policies
@@ -79,18 +80,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-ai-agent-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -98,8 +106,8 @@ metadata:
     name: binding-backplane-ai-agent-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-ai-agent-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
@@ -83,7 +83,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-ai-agent-sp
+    name: backplane-ai-agent-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -103,12 +103,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-ai-agent-sp
+    name: backplane-ai-agent-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-ai-agent-sp
+    name: backplane-ai-agent-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-ai-agent
     namespace: openshift-acm-policies
@@ -33,18 +34,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-ai-agent
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -52,8 +60,8 @@ metadata:
     name: binding-backplane-ai-agent
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-ai-agent
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
@@ -37,7 +37,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-ai-agent
+    name: backplane-ai-agent-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -57,12 +57,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-ai-agent
+    name: backplane-ai-agent-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-ai-agent
+    name: backplane-ai-agent-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee-sp
     namespace: openshift-acm-policies
@@ -109,18 +110,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cee-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -128,8 +136,8 @@ metadata:
     name: binding-backplane-cee-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cee-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -113,7 +113,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-cee-sp
+    name: backplane-cee-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -133,12 +133,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-cee-sp
+    name: backplane-cee-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-cee-sp
+    name: backplane-cee-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee
     namespace: openshift-acm-policies
@@ -190,18 +191,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cee
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -209,8 +217,8 @@ metadata:
     name: binding-backplane-cee
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cee
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -194,7 +194,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-cee
+    name: backplane-cee-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -214,12 +214,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-cee
+    name: backplane-cee-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-cee
+    name: backplane-cee-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse-sp
     namespace: openshift-acm-policies
@@ -79,18 +80,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cse-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -98,8 +106,8 @@ metadata:
     name: binding-backplane-cse-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cse-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -83,7 +83,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-cse-sp
+    name: backplane-cse-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -103,12 +103,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-cse-sp
+    name: backplane-cse-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-cse-sp
+    name: backplane-cse-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse
     namespace: openshift-acm-policies
@@ -33,18 +34,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cse
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -52,8 +60,8 @@ metadata:
     name: binding-backplane-cse
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cse
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -37,7 +37,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-cse
+    name: backplane-cse-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -57,12 +57,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-cse
+    name: backplane-cse-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-cse
+    name: backplane-cse-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-csm-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-csm-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-csm-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -111,7 +111,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-csm-sp
+    name: backplane-csm-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -131,12 +131,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-csm-sp
+    name: backplane-csm-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-csm-sp
+    name: backplane-csm-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-csm
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-csm
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-csm
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -146,7 +146,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-csm
+    name: backplane-csm-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -166,12 +166,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-csm
+    name: backplane-csm-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-csm
+    name: backplane-csm-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-elevated-sre
     namespace: openshift-acm-policies
@@ -86,18 +87,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-elevated-sre
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -105,8 +113,8 @@ metadata:
     name: binding-backplane-elevated-sre
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-elevated-sre
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -90,7 +90,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-elevated-sre
+    name: backplane-elevated-sre-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -110,12 +110,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-elevated-sre
+    name: backplane-elevated-sre-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-elevated-sre
+    name: backplane-elevated-sre-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-lpsre-sp
     namespace: openshift-acm-policies
@@ -206,18 +207,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-lpsre-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -225,8 +233,8 @@ metadata:
     name: binding-backplane-lpsre-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-lpsre-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
@@ -210,7 +210,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-lpsre-sp
+    name: backplane-lpsre-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -230,12 +230,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-lpsre-sp
+    name: backplane-lpsre-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-lpsre-sp
+    name: backplane-lpsre-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-lpsre
     namespace: openshift-acm-policies
@@ -287,18 +288,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-lpsre
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -306,8 +314,8 @@ metadata:
     name: binding-backplane-lpsre
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-lpsre
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
@@ -291,7 +291,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-lpsre
+    name: backplane-lpsre-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -311,12 +311,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-lpsre
+    name: backplane-lpsre-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-lpsre
+    name: backplane-lpsre-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
@@ -109,18 +110,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -128,8 +136,8 @@ metadata:
     name: binding-backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mcs-tier-two-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
@@ -113,7 +113,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-mcs-tier-two-sp
+    name: backplane-mcs-tier-two-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -133,12 +133,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-mcs-tier-two-sp
+    name: backplane-mcs-tier-two-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-mcs-tier-two-sp
+    name: backplane-mcs-tier-two-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mcs-tier-two
     namespace: openshift-acm-policies
@@ -181,18 +182,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mcs-tier-two
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -200,8 +208,8 @@ metadata:
     name: binding-backplane-mcs-tier-two
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mcs-tier-two
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
@@ -185,7 +185,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-mcs-tier-two
+    name: backplane-mcs-tier-two-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -205,12 +205,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-mcs-tier-two
+    name: backplane-mcs-tier-two-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-mcs-tier-two
+    name: backplane-mcs-tier-two-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mobb-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-mobb-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mobb-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -111,7 +111,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-mobb-sp
+    name: backplane-mobb-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -131,12 +131,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-mobb-sp
+    name: backplane-mobb-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-mobb-sp
+    name: backplane-mobb-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mobb
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-mobb
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mobb
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -146,7 +146,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-mobb
+    name: backplane-mobb-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -166,12 +166,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-mobb
+    name: backplane-mobb-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-mobb
+    name: backplane-mobb-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-ro-sp
     namespace: openshift-acm-policies
@@ -147,18 +148,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-ro-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -166,8 +174,8 @@ metadata:
     name: binding-backplane-srep-ro-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-ro-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
@@ -151,7 +151,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-srep-ro-sp
+    name: backplane-srep-ro-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -171,12 +171,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-srep-ro-sp
+    name: backplane-srep-ro-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-srep-ro-sp
+    name: backplane-srep-ro-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-ro
     namespace: openshift-acm-policies
@@ -403,18 +404,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-ro
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -422,8 +430,8 @@ metadata:
     name: binding-backplane-srep-ro
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-ro
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
@@ -407,7 +407,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-srep-ro
+    name: backplane-srep-ro-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -427,12 +427,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-srep-ro
+    name: backplane-srep-ro-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-srep-ro
+    name: backplane-srep-ro-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-sp
     namespace: openshift-acm-policies
@@ -145,18 +146,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -164,8 +172,8 @@ metadata:
     name: binding-backplane-srep-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -149,7 +149,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-srep-sp
+    name: backplane-srep-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -169,12 +169,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-srep-sp
+    name: backplane-srep-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-srep-sp
+    name: backplane-srep-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep
     namespace: openshift-acm-policies
@@ -307,18 +308,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -326,8 +334,8 @@ metadata:
     name: binding-backplane-srep
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -311,7 +311,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-srep
+    name: backplane-srep-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -331,12 +331,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-srep
+    name: backplane-srep-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-srep
+    name: backplane-srep-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-tam-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-tam-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-tam-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -111,7 +111,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-tam-sp
+    name: backplane-tam-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -131,12 +131,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-tam-sp
+    name: backplane-tam-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-tam-sp
+    name: backplane-tam-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-tam
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-tam
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-tam
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -146,7 +146,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane-tam
+    name: backplane-tam-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -166,12 +166,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane-tam
+    name: backplane-tam-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane-tam
+    name: backplane-tam-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane
     namespace: openshift-acm-policies
@@ -525,18 +526,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -544,8 +552,8 @@ metadata:
     name: binding-backplane
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -529,7 +529,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-backplane
+    name: backplane-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -549,12 +549,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-backplane
+    name: backplane-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-backplane
+    name: backplane-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
@@ -75,18 +76,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -94,8 +102,8 @@ metadata:
     name: binding-ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-ccs-dedicated-admins-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -79,7 +79,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-ccs-dedicated-admins-sp
+    name: ccs-dedicated-admins-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -99,12 +99,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-ccs-dedicated-admins-sp
+    name: ccs-dedicated-admins-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-ccs-dedicated-admins-sp
+    name: ccs-dedicated-admins-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins
     namespace: openshift-acm-policies
@@ -42,18 +43,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-ccs-dedicated-admins
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -61,8 +69,8 @@ metadata:
     name: binding-ccs-dedicated-admins
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-ccs-dedicated-admins
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -46,7 +46,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-ccs-dedicated-admins
+    name: ccs-dedicated-admins-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -66,12 +66,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-ccs-dedicated-admins
+    name: ccs-dedicated-admins-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-ccs-dedicated-admins
+    name: ccs-dedicated-admins-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: customer-registry-cas
     namespace: openshift-acm-policies
@@ -104,18 +105,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-customer-registry-cas
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -123,8 +131,8 @@ metadata:
     name: binding-customer-registry-cas
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-customer-registry-cas
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -108,7 +108,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-customer-registry-cas
+    name: customer-registry-cas-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -128,12 +128,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-customer-registry-cas
+    name: customer-registry-cas-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-customer-registry-cas
+    name: customer-registry-cas-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hcp-ze-ecr-creds
     namespace: openshift-acm-policies
@@ -529,29 +530,36 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hcp-ze-ecr-creds
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: api.openshift.com/hosted-cluster-egress-policy
-              operator: In
-              values:
-                - NoEgress
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: api.openshift.com/hosted-cluster-egress-policy
+                      operator: In
+                      values:
+                        - NoEgress
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -559,8 +567,8 @@ metadata:
     name: binding-hcp-ze-ecr-creds
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hcp-ze-ecr-creds
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
@@ -533,7 +533,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-hcp-ze-ecr-creds
+    name: hcp-ze-ecr-creds-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -564,12 +564,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-hcp-ze-ecr-creds
+    name: hcp-ze-ecr-creds-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-hcp-ze-ecr-creds
+    name: hcp-ze-ecr-creds-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hosted-uwm
     namespace: openshift-acm-policies
@@ -64,18 +65,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hosted-uwm
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -83,8 +91,8 @@ metadata:
     name: binding-hosted-uwm
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hosted-uwm
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -68,7 +68,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-hosted-uwm
+    name: hosted-uwm-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -88,12 +88,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-hosted-uwm
+    name: hosted-uwm-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-hosted-uwm
+    name: hosted-uwm-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hypershift-ovn-logging
     namespace: openshift-acm-policies
@@ -37,18 +38,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hypershift-ovn-logging
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/management-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/management-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -56,8 +64,8 @@ metadata:
     name: binding-hypershift-ovn-logging
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hypershift-ovn-logging
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-hypershift-ovn-logging
+    name: hypershift-ovn-logging-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -61,12 +61,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-hypershift-ovn-logging
+    name: hypershift-ovn-logging-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-hypershift-ovn-logging
+    name: hypershift-ovn-logging-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-ocpbugs-88685-metrics-proxy-memory-limit.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ocpbugs-88685-metrics-proxy-memory-limit.Policy.yaml
@@ -257,7 +257,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+    name: ocpbugs-88685-metrics-proxy-memory-limit-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -277,12 +277,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-ocpbugs-88685-metrics-proxy-memory-limit
+    name: ocpbugs-88685-metrics-proxy-memory-limit-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+    name: ocpbugs-88685-metrics-proxy-memory-limit-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-ocpbugs-88685-metrics-proxy-memory-limit.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ocpbugs-88685-metrics-proxy-memory-limit.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ocpbugs-88685-metrics-proxy-memory-limit
     namespace: openshift-acm-policies
@@ -253,18 +254,25 @@ spec:
                 severity: high
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-ocpbugs-88685-metrics-proxy-memory-limit
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/management-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/management-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -272,8 +280,8 @@ metadata:
     name: binding-ocpbugs-88685-metrics-proxy-memory-limit
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-ocpbugs-88685-metrics-proxy-memory-limit
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-backplane-managed-scripts
     namespace: openshift-acm-policies
@@ -61,18 +62,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-backplane-managed-scripts
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -80,8 +88,8 @@ metadata:
     name: binding-osd-backplane-managed-scripts
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-backplane-managed-scripts
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -65,7 +65,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-backplane-managed-scripts
+    name: osd-backplane-managed-scripts-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -85,12 +85,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-backplane-managed-scripts
+    name: osd-backplane-managed-scripts-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-backplane-managed-scripts
+    name: osd-backplane-managed-scripts-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-acks-hcp-5.0.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-acks-hcp-5.0.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-cluster-acks-hcp-5.0
     namespace: openshift-acm-policies
@@ -34,32 +35,39 @@ spec:
                 severity: high
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
-    name: placement-osd-cluster-acks-hcp-5.0
+    name: osd-cluster-acks-hcp-5.0-placement
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: In
-              values:
-                - "4.22"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: In
+                      values:
+                        - "4.22"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-cluster-acks-hcp-5.0
+    name: osd-cluster-acks-hcp-5.0-binding
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
-    name: placement-osd-cluster-acks-hcp-5.0
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: osd-cluster-acks-hcp-5.0-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-cluster-admin
     namespace: openshift-acm-policies
@@ -41,18 +42,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-cluster-admin
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -60,8 +68,8 @@ metadata:
     name: binding-osd-cluster-admin
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-cluster-admin
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -45,7 +45,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-cluster-admin
+    name: osd-cluster-admin-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -65,12 +65,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-cluster-admin
+    name: osd-cluster-admin-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-cluster-admin
+    name: osd-cluster-admin-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-customer-monitoring
     namespace: openshift-acm-policies
@@ -628,18 +629,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-customer-monitoring
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -647,8 +655,8 @@ metadata:
     name: binding-osd-customer-monitoring
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-customer-monitoring
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -632,7 +632,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-customer-monitoring
+    name: osd-customer-monitoring-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -652,12 +652,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-customer-monitoring
+    name: osd-customer-monitoring-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-customer-monitoring
+    name: osd-customer-monitoring-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
@@ -238,18 +239,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -257,8 +265,8 @@ metadata:
     name: binding-osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-script-resources
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -242,7 +242,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-delete-backplane-script-resources
+    name: osd-delete-backplane-script-resources-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -262,12 +262,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-delete-backplane-script-resources
+    name: osd-delete-backplane-script-resources-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-delete-backplane-script-resources
+    name: osd-delete-backplane-script-resources-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
@@ -72,18 +73,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -91,8 +99,8 @@ metadata:
     name: binding-osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-serviceaccounts-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -76,7 +76,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-delete-backplane-serviceaccounts-sp
+    name: osd-delete-backplane-serviceaccounts-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -96,12 +96,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-delete-backplane-serviceaccounts-sp
+    name: osd-delete-backplane-serviceaccounts-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-delete-backplane-serviceaccounts-sp
+    name: osd-delete-backplane-serviceaccounts-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
@@ -123,18 +124,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -142,8 +150,8 @@ metadata:
     name: binding-osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-serviceaccounts
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -127,7 +127,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-delete-backplane-serviceaccounts
+    name: osd-delete-backplane-serviceaccounts-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -147,12 +147,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-delete-backplane-serviceaccounts
+    name: osd-delete-backplane-serviceaccounts-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-delete-backplane-serviceaccounts
+    name: osd-delete-backplane-serviceaccounts-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-logging-unsupported
     namespace: openshift-acm-policies
@@ -172,18 +173,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-logging-unsupported
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -191,8 +199,8 @@ metadata:
     name: binding-osd-logging-unsupported
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-logging-unsupported
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -176,7 +176,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-logging-unsupported
+    name: osd-logging-unsupported-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -196,12 +196,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-logging-unsupported
+    name: osd-logging-unsupported-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-logging-unsupported
+    name: osd-logging-unsupported-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-must-gather-operator
     namespace: openshift-acm-policies
@@ -38,18 +39,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-must-gather-operator
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -57,8 +65,8 @@ metadata:
     name: binding-osd-must-gather-operator
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-must-gather-operator
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-must-gather-operator
+    name: osd-must-gather-operator-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -62,12 +62,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-must-gather-operator
+    name: osd-must-gather-operator-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-must-gather-operator
+    name: osd-must-gather-operator-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-openshift-operators-redhat
     namespace: openshift-acm-policies
@@ -97,18 +98,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-openshift-operators-redhat
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -116,8 +124,8 @@ metadata:
     name: binding-osd-openshift-operators-redhat
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-openshift-operators-redhat
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -101,7 +101,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-openshift-operators-redhat
+    name: osd-openshift-operators-redhat-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -121,12 +121,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-openshift-operators-redhat
+    name: osd-openshift-operators-redhat-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-openshift-operators-redhat
+    name: osd-openshift-operators-redhat-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -80,7 +80,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-pcap-collector
+    name: osd-pcap-collector-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -100,12 +100,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-pcap-collector
+    name: osd-pcap-collector-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-pcap-collector
+    name: osd-pcap-collector-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-pcap-collector
     namespace: openshift-acm-policies
@@ -76,18 +77,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-pcap-collector
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -95,8 +103,8 @@ metadata:
     name: binding-osd-pcap-collector
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-pcap-collector
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-project-request-template
     namespace: openshift-acm-policies
@@ -59,18 +60,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-project-request-template
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -78,8 +86,8 @@ metadata:
     name: binding-osd-project-request-template
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-project-request-template
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -63,7 +63,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-project-request-template
+    name: osd-project-request-template-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -83,12 +83,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-project-request-template
+    name: osd-project-request-template-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-project-request-template
+    name: osd-project-request-template-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
@@ -52,18 +53,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -71,8 +79,8 @@ metadata:
     name: binding-osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-user-workload-monitoring-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -56,7 +56,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-user-workload-monitoring-sp
+    name: osd-user-workload-monitoring-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -76,12 +76,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-user-workload-monitoring-sp
+    name: osd-user-workload-monitoring-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-user-workload-monitoring-sp
+    name: osd-user-workload-monitoring-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-user-workload-monitoring
     namespace: openshift-acm-policies
@@ -116,18 +117,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-user-workload-monitoring
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -135,8 +143,8 @@ metadata:
     name: binding-osd-user-workload-monitoring
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-user-workload-monitoring
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -120,7 +120,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-osd-user-workload-monitoring
+    name: osd-user-workload-monitoring-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -140,12 +140,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-user-workload-monitoring
+    name: osd-user-workload-monitoring-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-osd-user-workload-monitoring
+    name: osd-user-workload-monitoring-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
@@ -349,18 +350,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -368,8 +376,8 @@ metadata:
     name: binding-rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rbac-permissions-operator-config-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -353,7 +353,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rbac-permissions-operator-config-sp
+    name: rbac-permissions-operator-config-sp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -373,12 +373,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rbac-permissions-operator-config-sp
+    name: rbac-permissions-operator-config-sp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rbac-permissions-operator-config-sp
+    name: rbac-permissions-operator-config-sp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config
     namespace: openshift-acm-policies
@@ -1051,18 +1052,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rbac-permissions-operator-config
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -1070,8 +1078,8 @@ metadata:
     name: binding-rbac-permissions-operator-config
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rbac-permissions-operator-config
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -1055,7 +1055,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rbac-permissions-operator-config
+    name: rbac-permissions-operator-config-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -1075,12 +1075,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rbac-permissions-operator-config
+    name: rbac-permissions-operator-config-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rbac-permissions-operator-config
+    name: rbac-permissions-operator-config-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-console-branding-hcp
     namespace: openshift-acm-policies
@@ -39,18 +40,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-console-branding-hcp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -58,8 +66,8 @@ metadata:
     name: binding-rosa-console-branding-hcp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-console-branding-hcp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
@@ -43,7 +43,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rosa-console-branding-hcp
+    name: rosa-console-branding-hcp-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -63,12 +63,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-console-branding-hcp
+    name: rosa-console-branding-hcp-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rosa-console-branding-hcp
+    name: rosa-console-branding-hcp-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
@@ -135,18 +136,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -154,8 +162,8 @@ metadata:
     name: binding-rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-console-legacy-branding-configmap
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
@@ -139,7 +139,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rosa-console-legacy-branding-configmap
+    name: rosa-console-legacy-branding-configmap-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -159,12 +159,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-console-legacy-branding-configmap
+    name: rosa-console-legacy-branding-configmap-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rosa-console-legacy-branding-configmap
+    name: rosa-console-legacy-branding-configmap-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-ingress-certificate-check
     namespace: openshift-acm-policies
@@ -34,18 +35,25 @@ spec:
                 severity: low
     remediationAction: inform
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -53,8 +61,8 @@ metadata:
     name: binding-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-ingress-certificate-check
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
@@ -38,7 +38,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rosa-ingress-certificate-check
+    name: rosa-ingress-certificate-check-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -58,12 +58,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-ingress-certificate-check
+    name: rosa-ingress-certificate-check-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rosa-ingress-certificate-check
+    name: rosa-ingress-certificate-check-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
@@ -86,18 +87,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -105,8 +113,8 @@ metadata:
     name: binding-rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-ingress-certificate-policies
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -90,7 +90,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-rosa-ingress-certificate-policies
+    name: rosa-ingress-certificate-policies-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -110,12 +110,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-ingress-certificate-policies
+    name: rosa-ingress-certificate-policies-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-rosa-ingress-certificate-policies
+    name: rosa-ingress-certificate-policies-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
@@ -182,28 +183,35 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
-                - "4.19"
-                - "4.20"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+                        - "4.19"
+                        - "4.20"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -211,8 +219,8 @@ metadata:
     name: binding-srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-autonode-karpenter
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
@@ -186,7 +186,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-srep-vap-autonode-karpenter
+    name: srep-vap-autonode-karpenter-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -216,12 +216,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-srep-vap-autonode-karpenter
+    name: srep-vap-autonode-karpenter-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-srep-vap-autonode-karpenter
+    name: srep-vap-autonode-karpenter-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-hcp-node-label
     namespace: openshift-acm-policies
@@ -70,26 +71,33 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-hcp-node-label
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -97,8 +105,8 @@ metadata:
     name: binding-srep-vap-hcp-node-label
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-hcp-node-label
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
@@ -74,7 +74,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-srep-vap-hcp-node-label
+    name: srep-vap-hcp-node-label-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -102,12 +102,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-srep-vap-hcp-node-label
+    name: srep-vap-hcp-node-label-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-srep-vap-hcp-node-label
+    name: srep-vap-hcp-node-label-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
@@ -63,30 +64,37 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: api.openshift.com/win-li-enabled
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: api.openshift.com/win-li-enabled
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -94,8 +102,8 @@ metadata:
     name: binding-srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-vcpu-overcommit
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-    name: placement-srep-vap-vcpu-overcommit
+    name: srep-vap-vcpu-overcommit-placement
     namespace: openshift-acm-policies
 spec:
     predicates:
@@ -99,12 +99,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-srep-vap-vcpu-overcommit
+    name: srep-vap-vcpu-overcommit-binding
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: cluster.open-cluster-management.io
     kind: Placement
-    name: placement-srep-vap-vcpu-overcommit
+    name: srep-vap-vcpu-overcommit-placement
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy

--- a/deploy/rosa-oauth-templates-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
+++ b/deploy/rosa-oauth-templates-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-rosa-oauth-tpl-policies
+spec:
+  clusterSet: global

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7918,31 +7918,38 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
-        name: placement-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-placement
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: In
-            values:
-            - '4.22'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: In
+                values:
+                - '4.22'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-binding
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-osd-cluster-acks-hcp-5.0
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
+        name: osd-cluster-acks-hcp-5.0-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7953,6 +7960,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1500,6 +1500,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-acs
         namespace: openshift-acm-policies
@@ -2368,26 +2369,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-acs
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: api.openshift.com/addon-acs-fleetshard
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: api.openshift.com/addon-acs-fleetshard
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-acs
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-acs
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2399,6 +2407,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent-sp
         namespace: openshift-acm-policies
@@ -2472,26 +2481,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2503,6 +2519,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent
         namespace: openshift-acm-policies
@@ -2530,26 +2547,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2561,6 +2585,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
@@ -2664,26 +2689,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2695,6 +2727,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
         namespace: openshift-acm-policies
@@ -2879,26 +2912,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2910,6 +2950,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
         namespace: openshift-acm-policies
@@ -2983,26 +3024,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3014,6 +3062,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
         namespace: openshift-acm-policies
@@ -3041,26 +3090,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3072,6 +3128,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
         namespace: openshift-acm-policies
@@ -3173,26 +3230,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3204,6 +3268,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
         namespace: openshift-acm-policies
@@ -3340,26 +3405,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3371,6 +3443,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
         namespace: openshift-acm-policies
@@ -3451,26 +3524,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-elevated-sre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-elevated-sre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3482,6 +3562,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre-sp
         namespace: openshift-acm-policies
@@ -3682,26 +3763,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3713,6 +3801,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre
         namespace: openshift-acm-policies
@@ -3994,26 +4083,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4025,6 +4121,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
@@ -4128,26 +4225,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4159,6 +4263,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two
         namespace: openshift-acm-policies
@@ -4334,26 +4439,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4365,6 +4477,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
         namespace: openshift-acm-policies
@@ -4466,26 +4579,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4497,6 +4617,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
         namespace: openshift-acm-policies
@@ -4633,26 +4754,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4664,6 +4792,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro-sp
         namespace: openshift-acm-policies
@@ -4805,26 +4934,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4836,6 +4972,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro
         namespace: openshift-acm-policies
@@ -5233,26 +5370,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5264,6 +5408,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
         namespace: openshift-acm-policies
@@ -5403,26 +5548,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5434,6 +5586,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-acm-policies
@@ -5735,26 +5888,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5766,6 +5926,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
         namespace: openshift-acm-policies
@@ -5867,26 +6028,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5898,6 +6066,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
         namespace: openshift-acm-policies
@@ -6034,26 +6203,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6065,6 +6241,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
         namespace: openshift-acm-policies
@@ -6584,26 +6761,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6615,6 +6799,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
@@ -6684,26 +6869,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6715,6 +6907,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-acm-policies
@@ -6751,26 +6944,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6782,6 +6982,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
         namespace: openshift-acm-policies
@@ -6880,26 +7081,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-customer-registry-cas
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-customer-registry-cas
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6911,6 +7119,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hcp-ze-ecr-creds
         namespace: openshift-acm-policies
@@ -7197,37 +7406,44 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/hosted-cluster-egress-policy
-            operator: In
-            values:
-            - NoEgress
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/hosted-cluster-egress-policy
+                operator: In
+                values:
+                - NoEgress
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hcp-ze-ecr-creds
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7239,6 +7455,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hosted-uwm
         namespace: openshift-acm-policies
@@ -7297,26 +7514,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hosted-uwm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hosted-uwm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hosted-uwm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7328,6 +7552,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hypershift-ovn-logging
         namespace: openshift-acm-policies
@@ -7352,26 +7577,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hypershift-ovn-logging
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hypershift-ovn-logging
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hypershift-ovn-logging
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7383,6 +7615,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
@@ -7522,26 +7755,33 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7553,6 +7793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
@@ -7608,26 +7849,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-backplane-managed-scripts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7639,6 +7887,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-acks-hcp-5.0
         namespace: openshift-acm-policies
@@ -7732,26 +7981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-cluster-admin
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-cluster-admin
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7763,6 +8019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-customer-monitoring
         namespace: openshift-acm-policies
@@ -8385,26 +8642,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-customer-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-customer-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-customer-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8416,6 +8680,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
@@ -8614,26 +8879,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-script-resources
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8645,6 +8917,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
@@ -8711,26 +8984,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8742,6 +9022,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
@@ -8859,26 +9140,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8890,6 +9178,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-logging-unsupported
         namespace: openshift-acm-policies
@@ -9056,26 +9345,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-logging-unsupported
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-logging-unsupported
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-logging-unsupported
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9087,6 +9383,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
         namespace: openshift-acm-policies
@@ -9119,26 +9416,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-must-gather-operator
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-must-gather-operator
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9150,6 +9454,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
         namespace: openshift-acm-policies
@@ -9241,26 +9546,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-openshift-operators-redhat
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9272,6 +9584,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
         namespace: openshift-acm-policies
@@ -9342,26 +9655,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-pcap-collector
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-pcap-collector
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9373,6 +9693,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-project-request-template
         namespace: openshift-acm-policies
@@ -9426,26 +9747,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-project-request-template
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-project-request-template
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-project-request-template
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9457,6 +9785,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
@@ -9503,26 +9832,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9534,6 +9870,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring
         namespace: openshift-acm-policies
@@ -9644,26 +9981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9675,6 +10019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
@@ -10018,26 +10363,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -10049,6 +10401,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
         namespace: openshift-acm-policies
@@ -11094,26 +11447,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11125,6 +11485,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-branding-hcp
         namespace: openshift-acm-policies
@@ -11158,26 +11519,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-branding-hcp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11189,6 +11557,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
@@ -11319,26 +11688,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-legacy-branding-configmap
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11350,6 +11726,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
@@ -11378,26 +11755,33 @@ objects:
               remediationAction: inform
               severity: low
         remediationAction: inform
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-check
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11409,6 +11793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
@@ -11477,26 +11862,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-policies
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11508,6 +11900,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
@@ -11684,36 +12077,43 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
-            - '4.19'
-            - '4.20'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+                - '4.19'
+                - '4.20'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-autonode-karpenter
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11725,6 +12125,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-hcp-node-label
         namespace: openshift-acm-policies
@@ -11786,34 +12187,41 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-hcp-node-label
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11825,6 +12233,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
@@ -11889,38 +12298,45 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/win-li-enabled
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/win-li-enabled
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-vcpu-overcommit
       subjects:
       - apiGroup: policy.open-cluster-management.io

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1494,6 +1494,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-acm-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-acm-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -45139,6 +45146,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-rosa-oauth-tpl-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-rosa-oauth-tpl-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2372,7 +2372,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-acs
+        name: backplane-acs-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2391,12 +2391,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-acs
+        name: backplane-acs-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-acs
+        name: backplane-acs-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2484,7 +2484,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2503,12 +2503,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2550,7 +2550,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2569,12 +2569,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent
+        name: backplane-ai-agent-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2692,7 +2692,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2711,12 +2711,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee-sp
+        name: backplane-cee-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2915,7 +2915,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee
+        name: backplane-cee-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2934,12 +2934,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee
+        name: backplane-cee-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee
+        name: backplane-cee-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3027,7 +3027,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3046,12 +3046,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse-sp
+        name: backplane-cse-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3093,7 +3093,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse
+        name: backplane-cse-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3112,12 +3112,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse
+        name: backplane-cse-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse
+        name: backplane-cse-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3233,7 +3233,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3252,12 +3252,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm-sp
+        name: backplane-csm-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3408,7 +3408,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm
+        name: backplane-csm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3427,12 +3427,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm
+        name: backplane-csm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm
+        name: backplane-csm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3527,7 +3527,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3546,12 +3546,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-elevated-sre
+        name: backplane-elevated-sre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3766,7 +3766,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3785,12 +3785,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre-sp
+        name: backplane-lpsre-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4086,7 +4086,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4105,12 +4105,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre
+        name: backplane-lpsre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4228,7 +4228,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4247,12 +4247,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4442,7 +4442,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4461,12 +4461,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4582,7 +4582,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4601,12 +4601,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb-sp
+        name: backplane-mobb-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4757,7 +4757,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4776,12 +4776,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb
+        name: backplane-mobb-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4937,7 +4937,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4956,12 +4956,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5373,7 +5373,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5392,12 +5392,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro
+        name: backplane-srep-ro-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5551,7 +5551,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5570,12 +5570,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-sp
+        name: backplane-srep-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5891,7 +5891,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep
+        name: backplane-srep-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5910,12 +5910,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep
+        name: backplane-srep-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep
+        name: backplane-srep-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6031,7 +6031,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6050,12 +6050,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam-sp
+        name: backplane-tam-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6206,7 +6206,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam
+        name: backplane-tam-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6225,12 +6225,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam
+        name: backplane-tam-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam
+        name: backplane-tam-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6764,7 +6764,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane
+        name: backplane-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6783,12 +6783,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane
+        name: backplane-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane
+        name: backplane-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6872,7 +6872,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6891,12 +6891,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6947,7 +6947,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6966,12 +6966,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins
+        name: ccs-dedicated-admins-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7084,7 +7084,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7103,12 +7103,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-customer-registry-cas
+        name: customer-registry-cas-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7409,7 +7409,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7439,12 +7439,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7517,7 +7517,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7536,12 +7536,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hosted-uwm
+        name: hosted-uwm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7580,7 +7580,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7599,12 +7599,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hypershift-ovn-logging
+        name: hypershift-ovn-logging-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7758,7 +7758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7777,12 +7777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7852,7 +7852,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7871,12 +7871,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7984,7 +7984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8003,12 +8003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-admin
+        name: osd-cluster-admin-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8645,7 +8645,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8664,12 +8664,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-customer-monitoring
+        name: osd-customer-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8882,7 +8882,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8901,12 +8901,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8987,7 +8987,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9006,12 +9006,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9143,7 +9143,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9162,12 +9162,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9348,7 +9348,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9367,12 +9367,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-logging-unsupported
+        name: osd-logging-unsupported-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9419,7 +9419,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9438,12 +9438,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-must-gather-operator
+        name: osd-must-gather-operator-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9549,7 +9549,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9568,12 +9568,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9658,7 +9658,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9677,12 +9677,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-pcap-collector
+        name: osd-pcap-collector-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9750,7 +9750,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9769,12 +9769,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-project-request-template
+        name: osd-project-request-template-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9835,7 +9835,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9854,12 +9854,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9984,7 +9984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10003,12 +10003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -10366,7 +10366,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10385,12 +10385,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11450,7 +11450,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11469,12 +11469,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11522,7 +11522,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11541,12 +11541,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11691,7 +11691,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11710,12 +11710,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11758,7 +11758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11777,12 +11777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11865,7 +11865,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11884,12 +11884,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12080,7 +12080,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12109,12 +12109,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12190,7 +12190,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12217,12 +12217,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12301,7 +12301,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12332,12 +12332,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7918,31 +7918,38 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
-        name: placement-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-placement
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: In
-            values:
-            - '4.22'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: In
+                values:
+                - '4.22'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-binding
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-osd-cluster-acks-hcp-5.0
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
+        name: osd-cluster-acks-hcp-5.0-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7953,6 +7960,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1500,6 +1500,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-acs
         namespace: openshift-acm-policies
@@ -2368,26 +2369,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-acs
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: api.openshift.com/addon-acs-fleetshard
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: api.openshift.com/addon-acs-fleetshard
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-acs
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-acs
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2399,6 +2407,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent-sp
         namespace: openshift-acm-policies
@@ -2472,26 +2481,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2503,6 +2519,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent
         namespace: openshift-acm-policies
@@ -2530,26 +2547,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2561,6 +2585,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
@@ -2664,26 +2689,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2695,6 +2727,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
         namespace: openshift-acm-policies
@@ -2879,26 +2912,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2910,6 +2950,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
         namespace: openshift-acm-policies
@@ -2983,26 +3024,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3014,6 +3062,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
         namespace: openshift-acm-policies
@@ -3041,26 +3090,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3072,6 +3128,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
         namespace: openshift-acm-policies
@@ -3173,26 +3230,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3204,6 +3268,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
         namespace: openshift-acm-policies
@@ -3340,26 +3405,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3371,6 +3443,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
         namespace: openshift-acm-policies
@@ -3451,26 +3524,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-elevated-sre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-elevated-sre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3482,6 +3562,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre-sp
         namespace: openshift-acm-policies
@@ -3682,26 +3763,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3713,6 +3801,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre
         namespace: openshift-acm-policies
@@ -3994,26 +4083,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4025,6 +4121,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
@@ -4128,26 +4225,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4159,6 +4263,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two
         namespace: openshift-acm-policies
@@ -4334,26 +4439,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4365,6 +4477,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
         namespace: openshift-acm-policies
@@ -4466,26 +4579,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4497,6 +4617,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
         namespace: openshift-acm-policies
@@ -4633,26 +4754,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4664,6 +4792,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro-sp
         namespace: openshift-acm-policies
@@ -4805,26 +4934,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4836,6 +4972,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro
         namespace: openshift-acm-policies
@@ -5233,26 +5370,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5264,6 +5408,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
         namespace: openshift-acm-policies
@@ -5403,26 +5548,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5434,6 +5586,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-acm-policies
@@ -5735,26 +5888,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5766,6 +5926,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
         namespace: openshift-acm-policies
@@ -5867,26 +6028,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5898,6 +6066,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
         namespace: openshift-acm-policies
@@ -6034,26 +6203,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6065,6 +6241,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
         namespace: openshift-acm-policies
@@ -6584,26 +6761,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6615,6 +6799,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
@@ -6684,26 +6869,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6715,6 +6907,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-acm-policies
@@ -6751,26 +6944,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6782,6 +6982,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
         namespace: openshift-acm-policies
@@ -6880,26 +7081,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-customer-registry-cas
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-customer-registry-cas
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6911,6 +7119,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hcp-ze-ecr-creds
         namespace: openshift-acm-policies
@@ -7197,37 +7406,44 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/hosted-cluster-egress-policy
-            operator: In
-            values:
-            - NoEgress
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/hosted-cluster-egress-policy
+                operator: In
+                values:
+                - NoEgress
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hcp-ze-ecr-creds
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7239,6 +7455,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hosted-uwm
         namespace: openshift-acm-policies
@@ -7297,26 +7514,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hosted-uwm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hosted-uwm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hosted-uwm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7328,6 +7552,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hypershift-ovn-logging
         namespace: openshift-acm-policies
@@ -7352,26 +7577,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hypershift-ovn-logging
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hypershift-ovn-logging
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hypershift-ovn-logging
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7383,6 +7615,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
@@ -7522,26 +7755,33 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7553,6 +7793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
@@ -7608,26 +7849,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-backplane-managed-scripts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7639,6 +7887,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-acks-hcp-5.0
         namespace: openshift-acm-policies
@@ -7732,26 +7981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-cluster-admin
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-cluster-admin
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7763,6 +8019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-customer-monitoring
         namespace: openshift-acm-policies
@@ -8385,26 +8642,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-customer-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-customer-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-customer-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8416,6 +8680,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
@@ -8614,26 +8879,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-script-resources
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8645,6 +8917,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
@@ -8711,26 +8984,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8742,6 +9022,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
@@ -8859,26 +9140,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8890,6 +9178,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-logging-unsupported
         namespace: openshift-acm-policies
@@ -9056,26 +9345,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-logging-unsupported
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-logging-unsupported
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-logging-unsupported
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9087,6 +9383,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
         namespace: openshift-acm-policies
@@ -9119,26 +9416,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-must-gather-operator
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-must-gather-operator
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9150,6 +9454,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
         namespace: openshift-acm-policies
@@ -9241,26 +9546,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-openshift-operators-redhat
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9272,6 +9584,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
         namespace: openshift-acm-policies
@@ -9342,26 +9655,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-pcap-collector
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-pcap-collector
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9373,6 +9693,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-project-request-template
         namespace: openshift-acm-policies
@@ -9426,26 +9747,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-project-request-template
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-project-request-template
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-project-request-template
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9457,6 +9785,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
@@ -9503,26 +9832,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9534,6 +9870,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring
         namespace: openshift-acm-policies
@@ -9644,26 +9981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9675,6 +10019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
@@ -10018,26 +10363,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -10049,6 +10401,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
         namespace: openshift-acm-policies
@@ -11094,26 +11447,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11125,6 +11485,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-branding-hcp
         namespace: openshift-acm-policies
@@ -11158,26 +11519,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-branding-hcp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11189,6 +11557,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
@@ -11319,26 +11688,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-legacy-branding-configmap
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11350,6 +11726,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
@@ -11378,26 +11755,33 @@ objects:
               remediationAction: inform
               severity: low
         remediationAction: inform
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-check
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11409,6 +11793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
@@ -11477,26 +11862,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-policies
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11508,6 +11900,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
@@ -11684,36 +12077,43 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
-            - '4.19'
-            - '4.20'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+                - '4.19'
+                - '4.20'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-autonode-karpenter
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11725,6 +12125,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-hcp-node-label
         namespace: openshift-acm-policies
@@ -11786,34 +12187,41 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-hcp-node-label
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11825,6 +12233,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
@@ -11889,38 +12298,45 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/win-li-enabled
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/win-li-enabled
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-vcpu-overcommit
       subjects:
       - apiGroup: policy.open-cluster-management.io

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1494,6 +1494,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-acm-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-acm-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -45139,6 +45146,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-rosa-oauth-tpl-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-rosa-oauth-tpl-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2372,7 +2372,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-acs
+        name: backplane-acs-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2391,12 +2391,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-acs
+        name: backplane-acs-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-acs
+        name: backplane-acs-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2484,7 +2484,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2503,12 +2503,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2550,7 +2550,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2569,12 +2569,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent
+        name: backplane-ai-agent-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2692,7 +2692,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2711,12 +2711,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee-sp
+        name: backplane-cee-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2915,7 +2915,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee
+        name: backplane-cee-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2934,12 +2934,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee
+        name: backplane-cee-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee
+        name: backplane-cee-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3027,7 +3027,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3046,12 +3046,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse-sp
+        name: backplane-cse-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3093,7 +3093,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse
+        name: backplane-cse-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3112,12 +3112,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse
+        name: backplane-cse-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse
+        name: backplane-cse-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3233,7 +3233,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3252,12 +3252,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm-sp
+        name: backplane-csm-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3408,7 +3408,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm
+        name: backplane-csm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3427,12 +3427,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm
+        name: backplane-csm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm
+        name: backplane-csm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3527,7 +3527,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3546,12 +3546,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-elevated-sre
+        name: backplane-elevated-sre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3766,7 +3766,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3785,12 +3785,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre-sp
+        name: backplane-lpsre-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4086,7 +4086,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4105,12 +4105,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre
+        name: backplane-lpsre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4228,7 +4228,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4247,12 +4247,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4442,7 +4442,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4461,12 +4461,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4582,7 +4582,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4601,12 +4601,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb-sp
+        name: backplane-mobb-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4757,7 +4757,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4776,12 +4776,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb
+        name: backplane-mobb-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4937,7 +4937,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4956,12 +4956,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5373,7 +5373,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5392,12 +5392,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro
+        name: backplane-srep-ro-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5551,7 +5551,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5570,12 +5570,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-sp
+        name: backplane-srep-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5891,7 +5891,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep
+        name: backplane-srep-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5910,12 +5910,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep
+        name: backplane-srep-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep
+        name: backplane-srep-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6031,7 +6031,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6050,12 +6050,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam-sp
+        name: backplane-tam-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6206,7 +6206,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam
+        name: backplane-tam-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6225,12 +6225,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam
+        name: backplane-tam-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam
+        name: backplane-tam-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6764,7 +6764,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane
+        name: backplane-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6783,12 +6783,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane
+        name: backplane-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane
+        name: backplane-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6872,7 +6872,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6891,12 +6891,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6947,7 +6947,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6966,12 +6966,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins
+        name: ccs-dedicated-admins-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7084,7 +7084,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7103,12 +7103,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-customer-registry-cas
+        name: customer-registry-cas-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7409,7 +7409,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7439,12 +7439,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7517,7 +7517,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7536,12 +7536,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hosted-uwm
+        name: hosted-uwm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7580,7 +7580,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7599,12 +7599,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hypershift-ovn-logging
+        name: hypershift-ovn-logging-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7758,7 +7758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7777,12 +7777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7852,7 +7852,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7871,12 +7871,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7984,7 +7984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8003,12 +8003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-admin
+        name: osd-cluster-admin-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8645,7 +8645,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8664,12 +8664,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-customer-monitoring
+        name: osd-customer-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8882,7 +8882,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8901,12 +8901,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8987,7 +8987,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9006,12 +9006,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9143,7 +9143,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9162,12 +9162,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9348,7 +9348,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9367,12 +9367,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-logging-unsupported
+        name: osd-logging-unsupported-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9419,7 +9419,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9438,12 +9438,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-must-gather-operator
+        name: osd-must-gather-operator-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9549,7 +9549,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9568,12 +9568,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9658,7 +9658,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9677,12 +9677,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-pcap-collector
+        name: osd-pcap-collector-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9750,7 +9750,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9769,12 +9769,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-project-request-template
+        name: osd-project-request-template-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9835,7 +9835,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9854,12 +9854,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9984,7 +9984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10003,12 +10003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -10366,7 +10366,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10385,12 +10385,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11450,7 +11450,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11469,12 +11469,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11522,7 +11522,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11541,12 +11541,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11691,7 +11691,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11710,12 +11710,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11758,7 +11758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11777,12 +11777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11865,7 +11865,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11884,12 +11884,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12080,7 +12080,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12109,12 +12109,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12190,7 +12190,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12217,12 +12217,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12301,7 +12301,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12332,12 +12332,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7918,31 +7918,38 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
-        name: placement-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-placement
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: In
-            values:
-            - '4.22'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: In
+                values:
+                - '4.22'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-acks-hcp-5.0
+        name: osd-cluster-acks-hcp-5.0-binding
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-osd-cluster-acks-hcp-5.0
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
+        name: osd-cluster-acks-hcp-5.0-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7953,6 +7960,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1500,6 +1500,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-acs
         namespace: openshift-acm-policies
@@ -2368,26 +2369,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-acs
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: api.openshift.com/addon-acs-fleetshard
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: api.openshift.com/addon-acs-fleetshard
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-acs
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-acs
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2399,6 +2407,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent-sp
         namespace: openshift-acm-policies
@@ -2472,26 +2481,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2503,6 +2519,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-ai-agent
         namespace: openshift-acm-policies
@@ -2530,26 +2547,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-ai-agent
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-ai-agent
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-ai-agent
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2561,6 +2585,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
@@ -2664,26 +2689,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2695,6 +2727,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
         namespace: openshift-acm-policies
@@ -2879,26 +2912,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cee
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cee
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -2910,6 +2950,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
         namespace: openshift-acm-policies
@@ -2983,26 +3024,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3014,6 +3062,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
         namespace: openshift-acm-policies
@@ -3041,26 +3090,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-cse
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-cse
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3072,6 +3128,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
         namespace: openshift-acm-policies
@@ -3173,26 +3230,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3204,6 +3268,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
         namespace: openshift-acm-policies
@@ -3340,26 +3405,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-csm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-csm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3371,6 +3443,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
         namespace: openshift-acm-policies
@@ -3451,26 +3524,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-elevated-sre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-elevated-sre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3482,6 +3562,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre-sp
         namespace: openshift-acm-policies
@@ -3682,26 +3763,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -3713,6 +3801,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-lpsre
         namespace: openshift-acm-policies
@@ -3994,26 +4083,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-lpsre
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-lpsre
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-lpsre
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4025,6 +4121,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
@@ -4128,26 +4225,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4159,6 +4263,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mcs-tier-two
         namespace: openshift-acm-policies
@@ -4334,26 +4439,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mcs-tier-two
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mcs-tier-two
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4365,6 +4477,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
         namespace: openshift-acm-policies
@@ -4466,26 +4579,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4497,6 +4617,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
         namespace: openshift-acm-policies
@@ -4633,26 +4754,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-mobb
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-mobb
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4664,6 +4792,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro-sp
         namespace: openshift-acm-policies
@@ -4805,26 +4934,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -4836,6 +4972,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-ro
         namespace: openshift-acm-policies
@@ -5233,26 +5370,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-ro
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-ro
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-ro
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5264,6 +5408,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
         namespace: openshift-acm-policies
@@ -5403,26 +5548,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5434,6 +5586,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-acm-policies
@@ -5735,26 +5888,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-srep
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-srep
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5766,6 +5926,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
         namespace: openshift-acm-policies
@@ -5867,26 +6028,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -5898,6 +6066,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
         namespace: openshift-acm-policies
@@ -6034,26 +6203,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane-tam
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane-tam
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6065,6 +6241,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
         namespace: openshift-acm-policies
@@ -6584,26 +6761,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-backplane
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-backplane
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-backplane
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6615,6 +6799,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
@@ -6684,26 +6869,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6715,6 +6907,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-acm-policies
@@ -6751,26 +6944,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ccs-dedicated-admins
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ccs-dedicated-admins
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6782,6 +6982,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
         namespace: openshift-acm-policies
@@ -6880,26 +7081,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-customer-registry-cas
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-customer-registry-cas
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -6911,6 +7119,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hcp-ze-ecr-creds
         namespace: openshift-acm-policies
@@ -7197,37 +7406,44 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/hosted-cluster-egress-policy
-            operator: In
-            values:
-            - NoEgress
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/hosted-cluster-egress-policy
+                operator: In
+                values:
+                - NoEgress
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hcp-ze-ecr-creds
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hcp-ze-ecr-creds
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7239,6 +7455,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hosted-uwm
         namespace: openshift-acm-policies
@@ -7297,26 +7514,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hosted-uwm
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hosted-uwm
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hosted-uwm
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7328,6 +7552,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hypershift-ovn-logging
         namespace: openshift-acm-policies
@@ -7352,26 +7577,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-hypershift-ovn-logging
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-hypershift-ovn-logging
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-hypershift-ovn-logging
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7383,6 +7615,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
@@ -7522,26 +7755,33 @@ objects:
               remediationAction: enforce
               severity: high
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/management-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/management-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-ocpbugs-88685-metrics-proxy-memory-limit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-ocpbugs-88685-metrics-proxy-memory-limit
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7553,6 +7793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
@@ -7608,26 +7849,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-backplane-managed-scripts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7639,6 +7887,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-acks-hcp-5.0
         namespace: openshift-acm-policies
@@ -7732,26 +7981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-cluster-admin
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-cluster-admin
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -7763,6 +8019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-customer-monitoring
         namespace: openshift-acm-policies
@@ -8385,26 +8642,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-customer-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-customer-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-customer-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8416,6 +8680,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
@@ -8614,26 +8879,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-script-resources
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8645,6 +8917,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
@@ -8711,26 +8984,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8742,6 +9022,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
@@ -8859,26 +9140,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-delete-backplane-serviceaccounts
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-delete-backplane-serviceaccounts
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -8890,6 +9178,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-logging-unsupported
         namespace: openshift-acm-policies
@@ -9056,26 +9345,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-logging-unsupported
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-logging-unsupported
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-logging-unsupported
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9087,6 +9383,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
         namespace: openshift-acm-policies
@@ -9119,26 +9416,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-must-gather-operator
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-must-gather-operator
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9150,6 +9454,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
         namespace: openshift-acm-policies
@@ -9241,26 +9546,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-openshift-operators-redhat
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9272,6 +9584,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
         namespace: openshift-acm-policies
@@ -9342,26 +9655,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-pcap-collector
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-pcap-collector
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9373,6 +9693,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-project-request-template
         namespace: openshift-acm-policies
@@ -9426,26 +9747,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-project-request-template
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-project-request-template
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-project-request-template
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9457,6 +9785,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
@@ -9503,26 +9832,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9534,6 +9870,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-user-workload-monitoring
         namespace: openshift-acm-policies
@@ -9644,26 +9981,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-osd-user-workload-monitoring
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-osd-user-workload-monitoring
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -9675,6 +10019,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
@@ -10018,26 +10363,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config-sp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -10049,6 +10401,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
         namespace: openshift-acm-policies
@@ -11094,26 +11447,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rbac-permissions-operator-config
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11125,6 +11485,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-branding-hcp
         namespace: openshift-acm-policies
@@ -11158,26 +11519,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-branding-hcp
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-branding-hcp
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11189,6 +11557,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
@@ -11319,26 +11688,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-console-legacy-branding-configmap
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-console-legacy-branding-configmap
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11350,6 +11726,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
@@ -11378,26 +11755,33 @@ objects:
               remediationAction: inform
               severity: low
         remediationAction: inform
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-check
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11409,6 +11793,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
@@ -11477,26 +11862,33 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-rosa-ingress-certificate-policies
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-rosa-ingress-certificate-policies
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11508,6 +11900,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
@@ -11684,36 +12077,43 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
-            - '4.19'
-            - '4.20'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+                - '4.19'
+                - '4.20'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-autonode-karpenter
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-autonode-karpenter
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11725,6 +12125,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-hcp-node-label
         namespace: openshift-acm-policies
@@ -11786,34 +12187,41 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-hcp-node-label
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-hcp-node-label
       subjects:
       - apiGroup: policy.open-cluster-management.io
@@ -11825,6 +12233,7 @@ objects:
         annotations:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/description: ''
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
@@ -11889,38 +12298,45 @@ objects:
               remediationAction: enforce
               severity: low
         remediationAction: enforce
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
+    - apiVersion: cluster.open-cluster-management.io/v1beta1
+      kind: Placement
       metadata:
         name: placement-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-          - key: api.openshift.com/win-li-enabled
-            operator: In
-            values:
-            - 'true'
-          - key: openshiftVersion-major-minor
-            operator: NotIn
-            values:
-            - '4.14'
-            - '4.15'
-            - '4.16'
-            - '4.17'
-            - '4.18'
+        predicates:
+        - requiredClusterSelector:
+            labelSelector:
+              matchExpressions:
+              - key: hypershift.open-cluster-management.io/hosted-cluster
+                operator: In
+                values:
+                - 'true'
+              - key: api.openshift.com/win-li-enabled
+                operator: In
+                values:
+                - 'true'
+              - key: openshiftVersion-major-minor
+                operator: NotIn
+                values:
+                - '4.14'
+                - '4.15'
+                - '4.16'
+                - '4.17'
+                - '4.18'
+        tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
         name: binding-srep-vap-vcpu-overcommit
         namespace: openshift-acm-policies
       placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
+        apiGroup: cluster.open-cluster-management.io
+        kind: Placement
         name: placement-srep-vap-vcpu-overcommit
       subjects:
       - apiGroup: policy.open-cluster-management.io

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1494,6 +1494,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-acm-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-acm-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -45139,6 +45146,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-rosa-oauth-tpl-policies
+    - apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: global
+        namespace: openshift-rosa-oauth-tpl-policies
+      spec:
+        clusterSet: global
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2372,7 +2372,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-acs
+        name: backplane-acs-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2391,12 +2391,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-acs
+        name: backplane-acs-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-acs
+        name: backplane-acs-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2484,7 +2484,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2503,12 +2503,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent-sp
+        name: backplane-ai-agent-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2550,7 +2550,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2569,12 +2569,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-ai-agent
+        name: backplane-ai-agent-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-ai-agent
+        name: backplane-ai-agent-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2692,7 +2692,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2711,12 +2711,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee-sp
+        name: backplane-cee-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee-sp
+        name: backplane-cee-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -2915,7 +2915,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cee
+        name: backplane-cee-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -2934,12 +2934,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cee
+        name: backplane-cee-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cee
+        name: backplane-cee-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3027,7 +3027,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3046,12 +3046,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse-sp
+        name: backplane-cse-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse-sp
+        name: backplane-cse-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3093,7 +3093,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-cse
+        name: backplane-cse-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3112,12 +3112,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-cse
+        name: backplane-cse-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-cse
+        name: backplane-cse-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3233,7 +3233,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3252,12 +3252,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm-sp
+        name: backplane-csm-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm-sp
+        name: backplane-csm-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3408,7 +3408,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-csm
+        name: backplane-csm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3427,12 +3427,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-csm
+        name: backplane-csm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-csm
+        name: backplane-csm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3527,7 +3527,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3546,12 +3546,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-elevated-sre
+        name: backplane-elevated-sre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-elevated-sre
+        name: backplane-elevated-sre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -3766,7 +3766,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -3785,12 +3785,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre-sp
+        name: backplane-lpsre-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre-sp
+        name: backplane-lpsre-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4086,7 +4086,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4105,12 +4105,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-lpsre
+        name: backplane-lpsre-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-lpsre
+        name: backplane-lpsre-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4228,7 +4228,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4247,12 +4247,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two-sp
+        name: backplane-mcs-tier-two-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4442,7 +4442,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4461,12 +4461,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mcs-tier-two
+        name: backplane-mcs-tier-two-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4582,7 +4582,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4601,12 +4601,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb-sp
+        name: backplane-mobb-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb-sp
+        name: backplane-mobb-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4757,7 +4757,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4776,12 +4776,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-mobb
+        name: backplane-mobb-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-mobb
+        name: backplane-mobb-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -4937,7 +4937,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -4956,12 +4956,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro-sp
+        name: backplane-srep-ro-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5373,7 +5373,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5392,12 +5392,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-ro
+        name: backplane-srep-ro-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-ro
+        name: backplane-srep-ro-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5551,7 +5551,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5570,12 +5570,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep-sp
+        name: backplane-srep-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep-sp
+        name: backplane-srep-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -5891,7 +5891,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-srep
+        name: backplane-srep-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -5910,12 +5910,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-srep
+        name: backplane-srep-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-srep
+        name: backplane-srep-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6031,7 +6031,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6050,12 +6050,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam-sp
+        name: backplane-tam-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam-sp
+        name: backplane-tam-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6206,7 +6206,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane-tam
+        name: backplane-tam-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6225,12 +6225,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane-tam
+        name: backplane-tam-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane-tam
+        name: backplane-tam-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6764,7 +6764,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-backplane
+        name: backplane-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6783,12 +6783,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-backplane
+        name: backplane-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-backplane
+        name: backplane-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6872,7 +6872,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6891,12 +6891,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins-sp
+        name: ccs-dedicated-admins-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -6947,7 +6947,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -6966,12 +6966,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ccs-dedicated-admins
+        name: ccs-dedicated-admins-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ccs-dedicated-admins
+        name: ccs-dedicated-admins-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7084,7 +7084,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7103,12 +7103,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-customer-registry-cas
+        name: customer-registry-cas-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-customer-registry-cas
+        name: customer-registry-cas-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7409,7 +7409,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7439,12 +7439,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hcp-ze-ecr-creds
+        name: hcp-ze-ecr-creds-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7517,7 +7517,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7536,12 +7536,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hosted-uwm
+        name: hosted-uwm-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hosted-uwm
+        name: hosted-uwm-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7580,7 +7580,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7599,12 +7599,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-hypershift-ovn-logging
+        name: hypershift-ovn-logging-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-hypershift-ovn-logging
+        name: hypershift-ovn-logging-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7758,7 +7758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7777,12 +7777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-ocpbugs-88685-metrics-proxy-memory-limit
+        name: ocpbugs-88685-metrics-proxy-memory-limit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7852,7 +7852,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -7871,12 +7871,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-backplane-managed-scripts
+        name: osd-backplane-managed-scripts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -7984,7 +7984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8003,12 +8003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-cluster-admin
+        name: osd-cluster-admin-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-cluster-admin
+        name: osd-cluster-admin-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8645,7 +8645,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8664,12 +8664,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-customer-monitoring
+        name: osd-customer-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-customer-monitoring
+        name: osd-customer-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8882,7 +8882,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -8901,12 +8901,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-script-resources
+        name: osd-delete-backplane-script-resources-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -8987,7 +8987,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9006,12 +9006,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts-sp
+        name: osd-delete-backplane-serviceaccounts-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9143,7 +9143,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9162,12 +9162,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-delete-backplane-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9348,7 +9348,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9367,12 +9367,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-logging-unsupported
+        name: osd-logging-unsupported-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-logging-unsupported
+        name: osd-logging-unsupported-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9419,7 +9419,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9438,12 +9438,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-must-gather-operator
+        name: osd-must-gather-operator-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-must-gather-operator
+        name: osd-must-gather-operator-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9549,7 +9549,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9568,12 +9568,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-openshift-operators-redhat
+        name: osd-openshift-operators-redhat-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9658,7 +9658,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9677,12 +9677,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-pcap-collector
+        name: osd-pcap-collector-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-pcap-collector
+        name: osd-pcap-collector-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9750,7 +9750,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9769,12 +9769,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-project-request-template
+        name: osd-project-request-template-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-project-request-template
+        name: osd-project-request-template-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9835,7 +9835,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -9854,12 +9854,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring-sp
+        name: osd-user-workload-monitoring-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -9984,7 +9984,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10003,12 +10003,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-osd-user-workload-monitoring
+        name: osd-user-workload-monitoring-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -10366,7 +10366,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -10385,12 +10385,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config-sp
+        name: rbac-permissions-operator-config-sp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11450,7 +11450,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11469,12 +11469,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rbac-permissions-operator-config
+        name: rbac-permissions-operator-config-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11522,7 +11522,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11541,12 +11541,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-branding-hcp
+        name: rosa-console-branding-hcp-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11691,7 +11691,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11710,12 +11710,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-console-legacy-branding-configmap
+        name: rosa-console-legacy-branding-configmap-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11758,7 +11758,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11777,12 +11777,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-check
+        name: rosa-ingress-certificate-check-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -11865,7 +11865,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -11884,12 +11884,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-policies-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12080,7 +12080,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12109,12 +12109,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-autonode-karpenter
+        name: srep-vap-autonode-karpenter-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12190,7 +12190,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12217,12 +12217,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-hcp-node-label
+        name: srep-vap-hcp-node-label-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
@@ -12301,7 +12301,7 @@ objects:
     - apiVersion: cluster.open-cluster-management.io/v1beta1
       kind: Placement
       metadata:
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
         namespace: openshift-acm-policies
       spec:
         predicates:
@@ -12332,12 +12332,12 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-binding
         namespace: openshift-acm-policies
       placementRef:
         apiGroup: cluster.open-cluster-management.io
         kind: Placement
-        name: placement-srep-vap-vcpu-overcommit
+        name: srep-vap-vcpu-overcommit-placement
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy

--- a/scripts/add-annotations-tolerations.py
+++ b/scripts/add-annotations-tolerations.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+"""
+Post-processing script to add annotations to Policy resources and tolerations to Placement resources.
+This script is needed because:
+1. The PolicyGenerator tool doesn't support tolerations in the placement field of the template
+2. The description annotation needs to be explicitly set to an empty string on Policy resources
+"""
+
+import oyaml as yaml
+import os
+import sys
+from pathlib import Path
+
+PLACEMENT_TOLERATIONS = [
+    {
+        "key": "cluster.open-cluster-management.io/unavailable",
+        "operator": "Exists"
+    },
+    {
+        "key": "cluster.open-cluster-management.io/unreachable",
+        "operator": "Exists"
+    }
+]
+
+POLICY_DESCRIPTION_ANNOTATION = "policy.open-cluster-management.io/description"
+POLICY_DESCRIPTION_VALUE = ""
+
+def add_annotations_and_tolerations(policy_file):
+    """Add annotations to Policy resources and tolerations to Placement resources."""
+    try:
+        with open(policy_file, 'r') as f:
+            documents = list(yaml.safe_load_all(f))
+    except Exception as e:
+        print(f"Error reading {policy_file}: {e}", file=sys.stderr)
+        return False
+
+    modified = False
+    for doc in documents:
+        if not doc:
+            continue
+            
+        # Add description annotation to Policy resources
+        if doc.get('kind') == 'Policy':
+            if 'metadata' not in doc:
+                doc['metadata'] = {}
+            if 'annotations' not in doc['metadata']:
+                doc['metadata']['annotations'] = {}
+            # Only add if not already present
+            if POLICY_DESCRIPTION_ANNOTATION not in doc['metadata']['annotations']:
+                doc['metadata']['annotations'][POLICY_DESCRIPTION_ANNOTATION] = POLICY_DESCRIPTION_VALUE
+                modified = True
+        
+        # Add tolerations to Placement resources
+        elif doc.get('kind') == 'Placement':
+            if 'spec' not in doc:
+                doc['spec'] = {}
+            # Only add if not already present
+            if 'tolerations' not in doc['spec']:
+                doc['spec']['tolerations'] = PLACEMENT_TOLERATIONS
+                modified = True
+
+    if modified:
+        try:
+            with open(policy_file, 'w') as f:
+                yaml.dump_all(documents, f, default_flow_style=False)
+            return True
+        except Exception as e:
+            print(f"Error writing {policy_file}: {e}", file=sys.stderr)
+            return False
+
+    return True
+
+def main():
+    """Process all generated policy files."""
+    policy_dir = Path("deploy/acm-policies")
+    
+    if not policy_dir.exists():
+        print(f"Error: {policy_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    # Process all 50-GENERATED-*.Policy.yaml files
+    policy_files = list(policy_dir.glob("50-GENERATED-*.Policy.yaml"))
+    
+    if not policy_files:
+        print(f"No policy files found in {policy_dir}")
+        return
+
+    failed = []
+    for policy_file in sorted(policy_files):
+        if not add_annotations_and_tolerations(str(policy_file)):
+            failed.append(str(policy_file))
+            print(f"Failed to process {policy_file}")
+        else:
+            print(f"Processed {policy_file.name}")
+
+    if failed:
+        print(f"\nFailed files: {failed}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add-annotations-tolerations.py
+++ b/scripts/add-annotations-tolerations.py
@@ -100,3 +100,41 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+# ---------------------------------------------------------------------------
+# SLSRE-534: rename the generated PlacementBindings to "<policy>-binding".
+#
+# PolicyGenerator names a binding "binding-<policy>" whenever one policy owns
+# the placement; placementBindingDefaults.name only applies when several
+# policies are consolidated onto a single binding, so it cannot be used here.
+# The PlacementRule-era bindings carry exactly those names, so without this the
+# new binding would patch the old one in place instead of existing beside it,
+# and the staged rollout needs both live at once.
+#
+# Text pass rather than a YAML round-trip, to keep the diff to the one line.
+import glob as _glob
+import os as _os
+import re as _re
+
+_BINDING_NAME = _re.compile(r"^(\s*)name:\s+binding-(\S+)\s*$")
+
+for _path in sorted(_glob.glob(_os.path.join("deploy", "acm-policies", "50-GENERATED-*.yaml"))):
+    _lines = open(_path).read().splitlines(keepends=True)
+    _in_binding = False
+    _renamed = 0
+    for _i, _line in enumerate(_lines):
+        _stripped = _line.strip()
+        if _stripped.startswith("---"):
+            _in_binding = False
+        elif _stripped == "kind: PlacementBinding":
+            _in_binding = True
+        elif _in_binding:
+            _m = _BINDING_NAME.match(_line.rstrip("\n"))
+            if _m:
+                _lines[_i] = f"{_m.group(1)}name: {_m.group(2)}-binding\n"
+                _renamed += 1
+                _in_binding = False      # don't touch placementRef.name below
+    if _renamed:
+        open(_path, "w").write("".join(_lines))
+        print(f"Renamed {_renamed} PlacementBinding(s) in {_os.path.basename(_path)}")

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -118,6 +118,7 @@ for directory in sorted(directories, key=str.casefold):
             })
         label_selector = {'matchExpressions': match_expressions}
     policy_template['policyDefaults']['placement']['labelSelector'] = label_selector
+    policy_template['policyDefaults']['placement']['name'] = f'{policy_name}-placement'
     if not len(namespace_selectors) == 0:
         policy_template['policyDefaults']['namespaceSelector'] = namespace_selectors
     with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -100,7 +100,24 @@ for directory in sorted(directories, key=str.casefold):
         p['name'] = policy_name
         for m in p['manifests']:
             m['path'] = path
-    policy_template['policyDefaults']['placement']['clusterSelectors'] = cluster_selectors
+    # cluster_selectors may be either:
+    #  - a pre-formatted label selector from config.yaml (contains 'matchExpressions'
+    #    and/or 'matchLabels') -> pass through unchanged
+    #  - a flat {key: value} dict (the default hosted-cluster selector) -> convert
+    #    each pair into an 'In' matchExpression
+    if isinstance(cluster_selectors, dict) and (
+            'matchExpressions' in cluster_selectors or 'matchLabels' in cluster_selectors):
+        label_selector = cluster_selectors
+    else:
+        match_expressions = []
+        for key, value in cluster_selectors.items():
+            match_expressions.append({
+                'key': key,
+                'operator': 'In',
+                'values': [value]
+            })
+        label_selector = {'matchExpressions': match_expressions}
+    policy_template['policyDefaults']['placement']['labelSelector'] = label_selector
     if not len(namespace_selectors) == 0:
         policy_template['policyDefaults']['namespaceSelector'] = namespace_selectors
     with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:

--- a/scripts/generate-subjectpermissions-policy-config.py
+++ b/scripts/generate-subjectpermissions-policy-config.py
@@ -134,8 +134,10 @@ for directory in sorted(directories, key=str.casefold):
             #fill in the name and path in the policy generator template
             policy_template['metadata']['name'] = 'subjectpermission-policies'
             policy_template['policyDefaults']['consolidateManifests'] = False
+            sp_name = policy_name + '-sp'
             for p in policy_template['policies']:
-                p['name'] =  policy_name + '-sp'
+                p['name'] = sp_name
                 p['manifests'] = manifests
+            policy_template['policyDefaults']['placement']['name'] = f'{sp_name}-placement'
             with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:
                 yaml.dump(policy_template, output_file)

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -5,8 +5,12 @@ metadata:
 policyDefaults:
     namespace: openshift-acm-policies
     placement:
-        clusterSelectors:
-          hypershift.open-cluster-management.io/hosted-cluster: "true" # Can be overridden by script
+        labelSelector:
+            matchExpressions:
+                - key: hypershift.open-cluster-management.io/hosted-cluster
+                  operator: In
+                  values:
+                    - "true"
     remediationAction: enforce
     evaluationInterval:
         compliant: 2h


### PR DESCRIPTION
Migrate the ACM policy set from the deprecated `apps.open-cluster-management.io/v1` PlacementRule to `cluster.open-cluster-management.io/v1beta1` Placement.

[SLSRE-534](https://redhat.atlassian.net/browse/SLSRE-534) / [ROSAENG-3773](https://redhat.atlassian.net/browse/ROSAENG-3773)

### Commits

| | |
| --- | --- |
| `86609da8` | migrate 53 PlacementRules to Placements |
| `6a686e2e` | name generated Placements and PlacementBindings after their policy |
| `ca8ccdb2` | add the ManagedClusterSetBindings the Placements require |
| `41f4af80` | pin PolicyGenerator in the `IN_CONTAINER` branch |

### Why the objects are renamed

PolicyGenerator's default names (`placement-<x>` / `binding-<x>`) are the same names the PlacementRules being replaced already carry, and both APIs derive their PlacementDecision as `<name>-decision-1`. While the names are shared the Placement never receives a decision, so removing the PlacementRules leaves each Policy targeting zero clusters and the propagator rebuilds every replicated policy. Deriving the names from the policy removes the collision.

`placementBindingDefaults.name` only applies when several policies share one binding, and `generate-policy.sh` runs the generator once per policy, so the binding rename is a post-pass in `add-annotations-tolerations.py` rather than generator config.

### Validation

Dedicated ACM 2.15.6 hub, OCP 4.21.30, 9 ManagedClusters covering every distinct selector.

| Measure | default names | this branch |
| --- | --- | --- |
| Cluster selection parity | 52/52 identical | 52/52 identical |
| PlacementDecisions during coexistence | 52 | 104 |
| Replicated policies rebuilt | 278 of 282 | **0 of 284** |
| Replicated policies patched in place | 4 | 284 |

Replicated policy count held at 284 on every 2s sample through the deletion of all 52 PlacementRules — no window in which a Policy is unbound. Full evidence on [ROSAENG-3773](https://redhat.atlassian.net/browse/ROSAENG-3773).

### Notes for reviewers

- The `ManagedClusterSetBinding` manifests have no counterpart in the manifests being replaced; PlacementRule had no such requirement. Without them every Placement is unsatisfiable.
- `pr-check` was failing because CI's cached build-root image provides PolicyGenerator v1.12.4 regardless of `Dockerfile.prow`, and v1.12.4 serialises the same policies differently. The Makefile now downloads the pinned version in both branches; `.bin/` is gitignored.
- Scope is 52 of the 61 PlacementRules present on a service cluster. The other nine come from other sources and are unaffected.
