### PR TITLE
Adding runbook for ManagedNamespaceStuckTerminatingSRE alert

### DIFF
--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -24,3 +24,4 @@ spec:
         summary: "Namespace {{ $labels.namespace }} stuck in Terminating state"
         message: "Managed namespace {{ $labels.namespace }} has been stuck in Terminating state for more than 1 hour."
         description: "The namespace {{ $labels.namespace }} is stuck in Terminating phase. This typically indicates resources with finalizers that are preventing deletion. Check for stuck custom resources, APIService issues, or webhook problems."
+        runbook_url: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/ManagedNamespaceStuckTerminatingSRE.md"

--- a/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/namespace-stuck-terminating/100-managed-namespace-stuck-terminating.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-namespace-stuck-terminating
     rules:
     - expr: |
-        kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"} == 1
+        kube_namespace_status_phase{namespace=~"openshift-.*",namespace!~"(^openshift-debug-.*)", phase="Terminating"} == 1
       record: sre:record:namespace_stuck_terminating
     - alert: ManagedNamespaceStuckTerminatingSRE
       expr: |

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47869,6 +47869,7 @@ objects:
                 phase. This typically indicates resources with finalizers that are
                 preventing deletion. Check for stuck custom resources, APIService
                 issues, or webhook problems.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ManagedNamespaceStuckTerminatingSRE.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47848,8 +47848,8 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*",namespace!~"(^openshift-debug-.*)",
+              phase="Terminating"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47869,6 +47869,7 @@ objects:
                 phase. This typically indicates resources with finalizers that are
                 preventing deletion. Check for stuck custom resources, APIService
                 issues, or webhook problems.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ManagedNamespaceStuckTerminatingSRE.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47848,8 +47848,8 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*",namespace!~"(^openshift-debug-.*)",
+              phase="Terminating"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47869,6 +47869,7 @@ objects:
                 phase. This typically indicates resources with finalizers that are
                 preventing deletion. Check for stuck custom resources, APIService
                 issues, or webhook problems.
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ManagedNamespaceStuckTerminatingSRE.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47848,8 +47848,8 @@ objects:
         groups:
         - name: sre-namespace-stuck-terminating
           rules:
-          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*", phase="Terminating"}
-              == 1
+          - expr: 'kube_namespace_status_phase{namespace=~"openshift-.*",namespace!~"(^openshift-debug-.*)",
+              phase="Terminating"} == 1
 
               '
             record: sre:record:namespace_stuck_terminating


### PR DESCRIPTION
### What type of PR is this?
documentation

### What this PR does / why we need it?
Adding missing runbook annotation for ManagedNamespaceStuckTerminatingSRE alert

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a runbook link to the managed namespace stuck-terminating alert, making operational guidance easier to access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->