### PR TITLE
[ROSAENG-61271] restrict pcap-dedicated-admins SCC privileges

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -31,7 +31,6 @@ spec:
                         allowHostPorts: false
                         allowPrivilegedContainer: false
                         allowedCapabilities:
-                            - NET_ADMIN
                             - NET_RAW
                         apiVersion: security.openshift.io/v1
                         kind: SecurityContextConstraints
@@ -39,9 +38,9 @@ spec:
                             name: pcap-dedicated-admins
                         readOnlyRootFilesystem: false
                         runAsUser:
-                            type: RunAsAny
+                            type: MustRunAsNonRoot
                         seLinuxContext:
-                            type: RunAsAny
+                            type: MustRunAs
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
+++ b/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
@@ -9,10 +9,9 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
 allowedCapabilities:
-- 'NET_ADMIN'
 - 'NET_RAW'
 readOnlyRootFilesystem: false
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9237,7 +9237,6 @@ objects:
                   allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
-                  - NET_ADMIN
                   - NET_RAW
                   apiVersion: security.openshift.io/v1
                   kind: SecurityContextConstraints
@@ -9245,9 +9244,9 @@ objects:
                     name: pcap-dedicated-admins
                   readOnlyRootFilesystem: false
                   runAsUser:
-                    type: RunAsAny
+                    type: MustRunAsNonRoot
                   seLinuxContext:
-                    type: RunAsAny
+                    type: MustRunAs
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -40076,13 +40075,12 @@ objects:
       allowHostPorts: false
       allowPrivilegedContainer: false
       allowedCapabilities:
-      - NET_ADMIN
       - NET_RAW
       readOnlyRootFilesystem: false
       runAsUser:
-        type: RunAsAny
+        type: MustRunAsNonRoot
       seLinuxContext:
-        type: RunAsAny
+        type: MustRunAs
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9237,7 +9237,6 @@ objects:
                   allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
-                  - NET_ADMIN
                   - NET_RAW
                   apiVersion: security.openshift.io/v1
                   kind: SecurityContextConstraints
@@ -9245,9 +9244,9 @@ objects:
                     name: pcap-dedicated-admins
                   readOnlyRootFilesystem: false
                   runAsUser:
-                    type: RunAsAny
+                    type: MustRunAsNonRoot
                   seLinuxContext:
-                    type: RunAsAny
+                    type: MustRunAs
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -40076,13 +40075,12 @@ objects:
       allowHostPorts: false
       allowPrivilegedContainer: false
       allowedCapabilities:
-      - NET_ADMIN
       - NET_RAW
       readOnlyRootFilesystem: false
       runAsUser:
-        type: RunAsAny
+        type: MustRunAsNonRoot
       seLinuxContext:
-        type: RunAsAny
+        type: MustRunAs
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9237,7 +9237,6 @@ objects:
                   allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
-                  - NET_ADMIN
                   - NET_RAW
                   apiVersion: security.openshift.io/v1
                   kind: SecurityContextConstraints
@@ -9245,9 +9244,9 @@ objects:
                     name: pcap-dedicated-admins
                   readOnlyRootFilesystem: false
                   runAsUser:
-                    type: RunAsAny
+                    type: MustRunAsNonRoot
                   seLinuxContext:
-                    type: RunAsAny
+                    type: MustRunAs
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -40076,13 +40075,12 @@ objects:
       allowHostPorts: false
       allowPrivilegedContainer: false
       allowedCapabilities:
-      - NET_ADMIN
       - NET_RAW
       readOnlyRootFilesystem: false
       runAsUser:
-        type: RunAsAny
+        type: MustRunAsNonRoot
       seLinuxContext:
-        type: RunAsAny
+        type: MustRunAs
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
Drop NET_ADMIN (NET_RAW alone is sufficient for tcpdump-style capture), require non-root UID, and require the namespace's allocated MCS label instead of an unconfined SELinux context. This closes the gap that let any dedicated-admins group member bypass per-pod SELinux isolation and manipulate node networking as root.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted packet-capture workloads to the minimum required network capability.
  * Enforced non-root container execution.
  * Added SELinux labeling requirements for improved runtime isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->