### PR TITLE
ROSAENG-65557: reduce unnecessary kubelet restarts from ECR credential refresh

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
@@ -359,6 +359,10 @@ spec:
 
 
                             def main():
+                                jitter = int.from_bytes(os.urandom(2), "big") % 601
+                                log(f"Sleeping {jitter}s for jitter")
+                                subprocess.run(["sleep", str(jitter)], check=True)
+
                                 # Step 1: Discover all ECR registries from IDMS
                                 registries = discover_ecr_registries()
                                 if not registries:
@@ -393,14 +397,14 @@ spec:
                           labels:
                             app: ecr-credential-refresh
                         spec:
-                          schedule: "0 */4 * * *"
+                          schedule: "0 */5 * * *"
                           concurrencyPolicy: Forbid
                           successfulJobsHistoryLimit: 3
                           failedJobsHistoryLimit: 3
                           jobTemplate:
                             spec:
                               backoffLimit: 3
-                              activeDeadlineSeconds: 300
+                              activeDeadlineSeconds: 900
                               template:
                                 metadata:
                                   labels:

--- a/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
@@ -471,7 +471,6 @@ spec:
                             app.kubernetes.io/component: initial-refresh
                         spec:
                           activeDeadlineSeconds: 3600
-                          ttlSecondsAfterFinished: 3600
                           template:
                             metadata:
                               labels:

--- a/deploy/hcp-ze-ecr-creds/00-ecr-credential-refresh.ConfigurationPolicy.yaml
+++ b/deploy/hcp-ze-ecr-creds/00-ecr-credential-refresh.ConfigurationPolicy.yaml
@@ -473,7 +473,6 @@ spec:
             app.kubernetes.io/component: initial-refresh
         spec:
           activeDeadlineSeconds: 3600
-          ttlSecondsAfterFinished: 3600
           template:
             metadata:
               labels:

--- a/deploy/hcp-ze-ecr-creds/00-ecr-credential-refresh.ConfigurationPolicy.yaml
+++ b/deploy/hcp-ze-ecr-creds/00-ecr-credential-refresh.ConfigurationPolicy.yaml
@@ -2,8 +2,9 @@
 #
 # OHSS-49424: The global-pull-secret-syncer bug was backported to
 # OCP 4.18+ where it overwrites kubelet ECR credentials.
-# This CronJob refreshes additional-pull-secret every 4 hours
-# so HCCO can merge it into global-pull-secret.
+# This CronJob refreshes additional-pull-secret every 5 hours,
+# so HCCO can merge it into global-pull-secret. A random delay of
+# up to 10m is added to stagger kubelet restarts.
 #
 # The script auto-detects zero-egress clusters by checking for IDMS.
 # Non-zero-egress clusters will exit early with success (no-op).
@@ -304,7 +305,7 @@ spec:
                         raise RuntimeError(
                             f"Existing .dockerconfigjson is not valid: {e}"
                         )
-    
+
                     managed = set(registries)
                     merged_auths = {
                         k: v for k, v in (existing.get("auths") or {}).items()
@@ -360,6 +361,10 @@ spec:
 
 
             def main():
+                jitter = int.from_bytes(os.urandom(2), "big") % 601
+                log(f"Sleeping {jitter}s for jitter")
+                subprocess.run(["sleep", str(jitter)], check=True)
+
                 # Step 1: Discover all ECR registries from IDMS
                 registries = discover_ecr_registries()
                 if not registries:
@@ -394,14 +399,14 @@ spec:
           labels:
             app: ecr-credential-refresh
         spec:
-          schedule: "0 */4 * * *"
+          schedule: "0 */5 * * *"
           concurrencyPolicy: Forbid
           successfulJobsHistoryLimit: 3
           failedJobsHistoryLimit: 3
           jobTemplate:
             spec:
               backoffLimit: 3
-              activeDeadlineSeconds: 300
+              activeDeadlineSeconds: 900
               template:
                 metadata:
                   labels:

--- a/deploy/hcp-ze-ecr-creds/config.yaml
+++ b/deploy/hcp-ze-ecr-creds/config.yaml
@@ -2,8 +2,9 @@
 #
 # OHSS-49424: The global-pull-secret-syncer bug was backported to
 # OCP 4.18+ where it overwrites kubelet ECR credentials.
-# This CronJob refreshes additional-pull-secret every 4 hours
-# so HCCO can merge it into global-pull-secret.
+# This CronJob refreshes additional-pull-secret every 5 hours,
+# so HCCO can merge it into global-pull-secret. A random delay of
+# up to 10m is added to stagger kubelet restarts.
 #
 # The script auto-detects zero-egress clusters by checking for IDMS.
 # Non-zero-egress clusters will exit early with success (no-op).

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7164,35 +7164,35 @@ objects:
                 \ Job\n    metadata:\n      name: ecr-credential-refresh-initial\n\
                 \      namespace: kube-system\n      labels:\n        app: ecr-credential-refresh\n\
                 \        app.kubernetes.io/component: initial-refresh\n    spec:\n\
-                \      activeDeadlineSeconds: 3600\n      ttlSecondsAfterFinished:\
-                \ 3600\n      template:\n        metadata:\n          labels:\n  \
-                \          app: ecr-credential-refresh\n        spec:\n          serviceAccountName:\
-                \ ecr-credential-refresh\n          restartPolicy: Never\n       \
-                \   nodeSelector:\n            node-role.kubernetes.io/worker: \"\"\
-                \n          tolerations:\n            - operator: Exists\n       \
-                \   hostNetwork: true\n          dnsPolicy: Default\n          containers:\n\
-                \            - name: refresh\n              # Dynamic lookup: get\
-                \ image from node-resolver DaemonSet\n              # This image is\
-                \ guaranteed to be cached on worker nodes\n              # Uses index\
-                \ function since ACM templates don't support bracket notation\n  \
-                \            image: '{{ (index (lookup \"apps/v1\" \"DaemonSet\" \"\
-                openshift-dns\" \"node-resolver\").spec.template.spec.containers 0).image\
-                \ }}'\n              imagePullPolicy: IfNotPresent\n             \
-                \ command:\n                - python3\n                - /scripts/refresh.py\n\
-                \              volumeMounts:\n                - name: script\n   \
-                \               mountPath: /scripts\n                  readOnly: true\n\
-                \                - name: host-root\n                  mountPath: /host\n\
-                \                  readOnly: true\n              resources:\n    \
-                \            requests:\n                  cpu: 10m\n             \
-                \     memory: 64Mi\n                limits:\n                  cpu:\
-                \ 100m\n                  memory: 128Mi\n              securityContext:\n\
-                \                allowPrivilegeEscalation: false\n               \
-                \ capabilities:\n                  drop:\n                    - ALL\n\
-                \                seccompProfile:\n                  type: RuntimeDefault\n\
-                \          volumes:\n            - name: script\n              configMap:\n\
-                \                name: ecr-credential-refresh-script\n           \
-                \     defaultMode: 0755\n            - name: host-root\n         \
-                \     hostPath:\n                path: /\n                type: Directory\n"
+                \      activeDeadlineSeconds: 3600\n      template:\n        metadata:\n\
+                \          labels:\n            app: ecr-credential-refresh\n    \
+                \    spec:\n          serviceAccountName: ecr-credential-refresh\n\
+                \          restartPolicy: Never\n          nodeSelector:\n       \
+                \     node-role.kubernetes.io/worker: \"\"\n          tolerations:\n\
+                \            - operator: Exists\n          hostNetwork: true\n   \
+                \       dnsPolicy: Default\n          containers:\n            - name:\
+                \ refresh\n              # Dynamic lookup: get image from node-resolver\
+                \ DaemonSet\n              # This image is guaranteed to be cached\
+                \ on worker nodes\n              # Uses index function since ACM templates\
+                \ don't support bracket notation\n              image: '{{ (index\
+                \ (lookup \"apps/v1\" \"DaemonSet\" \"openshift-dns\" \"node-resolver\"\
+                ).spec.template.spec.containers 0).image }}'\n              imagePullPolicy:\
+                \ IfNotPresent\n              command:\n                - python3\n\
+                \                - /scripts/refresh.py\n              volumeMounts:\n\
+                \                - name: script\n                  mountPath: /scripts\n\
+                \                  readOnly: true\n                - name: host-root\n\
+                \                  mountPath: /host\n                  readOnly: true\n\
+                \              resources:\n                requests:\n           \
+                \       cpu: 10m\n                  memory: 64Mi\n               \
+                \ limits:\n                  cpu: 100m\n                  memory:\
+                \ 128Mi\n              securityContext:\n                allowPrivilegeEscalation:\
+                \ false\n                capabilities:\n                  drop:\n\
+                \                    - ALL\n                seccompProfile:\n    \
+                \              type: RuntimeDefault\n          volumes:\n        \
+                \    - name: script\n              configMap:\n                name:\
+                \ ecr-credential-refresh-script\n                defaultMode: 0755\n\
+                \            - name: host-root\n              hostPath:\n        \
+                \        path: /\n                type: Directory\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7104,27 +7104,30 @@ objects:
                 Failed to create secret: {result.stderr}\")\n                log(f\"\
                 Successfully created {SECRET_NAME}\")\n\n            for registry\
                 \ in registries:\n                log(f\"  - {registry}\")\n\n\n \
-                \       def main():\n            # Step 1: Discover all ECR registries\
-                \ from IDMS\n            registries = discover_ecr_registries()\n\
-                \            if not registries:\n                log(\"Skipping -\
-                \ no ECR IDMS mirrors found (not a zero-egress cluster)\")\n     \
-                \           return\n\n            log(f\"Starting ECR credential refresh\
-                \ for {len(registries)} registry(s)\")\n\n            # Step 2: Get\
-                \ ECR token (same token works for all registries)\n            ecr_password\
-                \ = get_ecr_token(registries[0])\n\n            # Step 3: Update the\
-                \ secret with auth entries for all registries\n            update_secret(registries,\
-                \ ecr_password)\n\n            log(\"ECR credential refresh completed\
-                \ successfully\")\n\n\n        if __name__ == \"__main__\":\n    \
-                \        try:\n                main()\n            except Exception\
-                \ as e:\n                log(f\"FATAL - {e}\")\n                sys.exit(1)\n\
-                - complianceType: mustonlyhave\n  metadataComplianceType: musthave\n\
-                \  objectDefinition:\n    apiVersion: batch/v1\n    kind: CronJob\n\
-                \    metadata:\n      name: ecr-credential-refresh\n      namespace:\
-                \ kube-system\n      labels:\n        app: ecr-credential-refresh\n\
-                \    spec:\n      schedule: \"0 */4 * * *\"\n      concurrencyPolicy:\
-                \ Forbid\n      successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
+                \       def main():\n            jitter = int.from_bytes(os.urandom(2),\
+                \ \"big\") % 601\n            log(f\"Sleeping {jitter}s for jitter\"\
+                )\n            subprocess.run([\"sleep\", str(jitter)], check=True)\n\
+                \n            # Step 1: Discover all ECR registries from IDMS\n  \
+                \          registries = discover_ecr_registries()\n            if\
+                \ not registries:\n                log(\"Skipping - no ECR IDMS mirrors\
+                \ found (not a zero-egress cluster)\")\n                return\n\n\
+                \            log(f\"Starting ECR credential refresh for {len(registries)}\
+                \ registry(s)\")\n\n            # Step 2: Get ECR token (same token\
+                \ works for all registries)\n            ecr_password = get_ecr_token(registries[0])\n\
+                \n            # Step 3: Update the secret with auth entries for all\
+                \ registries\n            update_secret(registries, ecr_password)\n\
+                \n            log(\"ECR credential refresh completed successfully\"\
+                )\n\n\n        if __name__ == \"__main__\":\n            try:\n  \
+                \              main()\n            except Exception as e:\n      \
+                \          log(f\"FATAL - {e}\")\n                sys.exit(1)\n- complianceType:\
+                \ mustonlyhave\n  metadataComplianceType: musthave\n  objectDefinition:\n\
+                \    apiVersion: batch/v1\n    kind: CronJob\n    metadata:\n    \
+                \  name: ecr-credential-refresh\n      namespace: kube-system\n  \
+                \    labels:\n        app: ecr-credential-refresh\n    spec:\n   \
+                \   schedule: \"0 */5 * * *\"\n      concurrencyPolicy: Forbid\n \
+                \     successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
                 \ 3\n      jobTemplate:\n        spec:\n          backoffLimit: 3\n\
-                \          activeDeadlineSeconds: 300\n          template:\n     \
+                \          activeDeadlineSeconds: 900\n          template:\n     \
                 \       metadata:\n              labels:\n                app: ecr-credential-refresh\n\
                 \            spec:\n              serviceAccountName: ecr-credential-refresh\n\
                 \              restartPolicy: OnFailure\n              nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7164,35 +7164,35 @@ objects:
                 \ Job\n    metadata:\n      name: ecr-credential-refresh-initial\n\
                 \      namespace: kube-system\n      labels:\n        app: ecr-credential-refresh\n\
                 \        app.kubernetes.io/component: initial-refresh\n    spec:\n\
-                \      activeDeadlineSeconds: 3600\n      ttlSecondsAfterFinished:\
-                \ 3600\n      template:\n        metadata:\n          labels:\n  \
-                \          app: ecr-credential-refresh\n        spec:\n          serviceAccountName:\
-                \ ecr-credential-refresh\n          restartPolicy: Never\n       \
-                \   nodeSelector:\n            node-role.kubernetes.io/worker: \"\"\
-                \n          tolerations:\n            - operator: Exists\n       \
-                \   hostNetwork: true\n          dnsPolicy: Default\n          containers:\n\
-                \            - name: refresh\n              # Dynamic lookup: get\
-                \ image from node-resolver DaemonSet\n              # This image is\
-                \ guaranteed to be cached on worker nodes\n              # Uses index\
-                \ function since ACM templates don't support bracket notation\n  \
-                \            image: '{{ (index (lookup \"apps/v1\" \"DaemonSet\" \"\
-                openshift-dns\" \"node-resolver\").spec.template.spec.containers 0).image\
-                \ }}'\n              imagePullPolicy: IfNotPresent\n             \
-                \ command:\n                - python3\n                - /scripts/refresh.py\n\
-                \              volumeMounts:\n                - name: script\n   \
-                \               mountPath: /scripts\n                  readOnly: true\n\
-                \                - name: host-root\n                  mountPath: /host\n\
-                \                  readOnly: true\n              resources:\n    \
-                \            requests:\n                  cpu: 10m\n             \
-                \     memory: 64Mi\n                limits:\n                  cpu:\
-                \ 100m\n                  memory: 128Mi\n              securityContext:\n\
-                \                allowPrivilegeEscalation: false\n               \
-                \ capabilities:\n                  drop:\n                    - ALL\n\
-                \                seccompProfile:\n                  type: RuntimeDefault\n\
-                \          volumes:\n            - name: script\n              configMap:\n\
-                \                name: ecr-credential-refresh-script\n           \
-                \     defaultMode: 0755\n            - name: host-root\n         \
-                \     hostPath:\n                path: /\n                type: Directory\n"
+                \      activeDeadlineSeconds: 3600\n      template:\n        metadata:\n\
+                \          labels:\n            app: ecr-credential-refresh\n    \
+                \    spec:\n          serviceAccountName: ecr-credential-refresh\n\
+                \          restartPolicy: Never\n          nodeSelector:\n       \
+                \     node-role.kubernetes.io/worker: \"\"\n          tolerations:\n\
+                \            - operator: Exists\n          hostNetwork: true\n   \
+                \       dnsPolicy: Default\n          containers:\n            - name:\
+                \ refresh\n              # Dynamic lookup: get image from node-resolver\
+                \ DaemonSet\n              # This image is guaranteed to be cached\
+                \ on worker nodes\n              # Uses index function since ACM templates\
+                \ don't support bracket notation\n              image: '{{ (index\
+                \ (lookup \"apps/v1\" \"DaemonSet\" \"openshift-dns\" \"node-resolver\"\
+                ).spec.template.spec.containers 0).image }}'\n              imagePullPolicy:\
+                \ IfNotPresent\n              command:\n                - python3\n\
+                \                - /scripts/refresh.py\n              volumeMounts:\n\
+                \                - name: script\n                  mountPath: /scripts\n\
+                \                  readOnly: true\n                - name: host-root\n\
+                \                  mountPath: /host\n                  readOnly: true\n\
+                \              resources:\n                requests:\n           \
+                \       cpu: 10m\n                  memory: 64Mi\n               \
+                \ limits:\n                  cpu: 100m\n                  memory:\
+                \ 128Mi\n              securityContext:\n                allowPrivilegeEscalation:\
+                \ false\n                capabilities:\n                  drop:\n\
+                \                    - ALL\n                seccompProfile:\n    \
+                \              type: RuntimeDefault\n          volumes:\n        \
+                \    - name: script\n              configMap:\n                name:\
+                \ ecr-credential-refresh-script\n                defaultMode: 0755\n\
+                \            - name: host-root\n              hostPath:\n        \
+                \        path: /\n                type: Directory\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7104,27 +7104,30 @@ objects:
                 Failed to create secret: {result.stderr}\")\n                log(f\"\
                 Successfully created {SECRET_NAME}\")\n\n            for registry\
                 \ in registries:\n                log(f\"  - {registry}\")\n\n\n \
-                \       def main():\n            # Step 1: Discover all ECR registries\
-                \ from IDMS\n            registries = discover_ecr_registries()\n\
-                \            if not registries:\n                log(\"Skipping -\
-                \ no ECR IDMS mirrors found (not a zero-egress cluster)\")\n     \
-                \           return\n\n            log(f\"Starting ECR credential refresh\
-                \ for {len(registries)} registry(s)\")\n\n            # Step 2: Get\
-                \ ECR token (same token works for all registries)\n            ecr_password\
-                \ = get_ecr_token(registries[0])\n\n            # Step 3: Update the\
-                \ secret with auth entries for all registries\n            update_secret(registries,\
-                \ ecr_password)\n\n            log(\"ECR credential refresh completed\
-                \ successfully\")\n\n\n        if __name__ == \"__main__\":\n    \
-                \        try:\n                main()\n            except Exception\
-                \ as e:\n                log(f\"FATAL - {e}\")\n                sys.exit(1)\n\
-                - complianceType: mustonlyhave\n  metadataComplianceType: musthave\n\
-                \  objectDefinition:\n    apiVersion: batch/v1\n    kind: CronJob\n\
-                \    metadata:\n      name: ecr-credential-refresh\n      namespace:\
-                \ kube-system\n      labels:\n        app: ecr-credential-refresh\n\
-                \    spec:\n      schedule: \"0 */4 * * *\"\n      concurrencyPolicy:\
-                \ Forbid\n      successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
+                \       def main():\n            jitter = int.from_bytes(os.urandom(2),\
+                \ \"big\") % 601\n            log(f\"Sleeping {jitter}s for jitter\"\
+                )\n            subprocess.run([\"sleep\", str(jitter)], check=True)\n\
+                \n            # Step 1: Discover all ECR registries from IDMS\n  \
+                \          registries = discover_ecr_registries()\n            if\
+                \ not registries:\n                log(\"Skipping - no ECR IDMS mirrors\
+                \ found (not a zero-egress cluster)\")\n                return\n\n\
+                \            log(f\"Starting ECR credential refresh for {len(registries)}\
+                \ registry(s)\")\n\n            # Step 2: Get ECR token (same token\
+                \ works for all registries)\n            ecr_password = get_ecr_token(registries[0])\n\
+                \n            # Step 3: Update the secret with auth entries for all\
+                \ registries\n            update_secret(registries, ecr_password)\n\
+                \n            log(\"ECR credential refresh completed successfully\"\
+                )\n\n\n        if __name__ == \"__main__\":\n            try:\n  \
+                \              main()\n            except Exception as e:\n      \
+                \          log(f\"FATAL - {e}\")\n                sys.exit(1)\n- complianceType:\
+                \ mustonlyhave\n  metadataComplianceType: musthave\n  objectDefinition:\n\
+                \    apiVersion: batch/v1\n    kind: CronJob\n    metadata:\n    \
+                \  name: ecr-credential-refresh\n      namespace: kube-system\n  \
+                \    labels:\n        app: ecr-credential-refresh\n    spec:\n   \
+                \   schedule: \"0 */5 * * *\"\n      concurrencyPolicy: Forbid\n \
+                \     successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
                 \ 3\n      jobTemplate:\n        spec:\n          backoffLimit: 3\n\
-                \          activeDeadlineSeconds: 300\n          template:\n     \
+                \          activeDeadlineSeconds: 900\n          template:\n     \
                 \       metadata:\n              labels:\n                app: ecr-credential-refresh\n\
                 \            spec:\n              serviceAccountName: ecr-credential-refresh\n\
                 \              restartPolicy: OnFailure\n              nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7164,35 +7164,35 @@ objects:
                 \ Job\n    metadata:\n      name: ecr-credential-refresh-initial\n\
                 \      namespace: kube-system\n      labels:\n        app: ecr-credential-refresh\n\
                 \        app.kubernetes.io/component: initial-refresh\n    spec:\n\
-                \      activeDeadlineSeconds: 3600\n      ttlSecondsAfterFinished:\
-                \ 3600\n      template:\n        metadata:\n          labels:\n  \
-                \          app: ecr-credential-refresh\n        spec:\n          serviceAccountName:\
-                \ ecr-credential-refresh\n          restartPolicy: Never\n       \
-                \   nodeSelector:\n            node-role.kubernetes.io/worker: \"\"\
-                \n          tolerations:\n            - operator: Exists\n       \
-                \   hostNetwork: true\n          dnsPolicy: Default\n          containers:\n\
-                \            - name: refresh\n              # Dynamic lookup: get\
-                \ image from node-resolver DaemonSet\n              # This image is\
-                \ guaranteed to be cached on worker nodes\n              # Uses index\
-                \ function since ACM templates don't support bracket notation\n  \
-                \            image: '{{ (index (lookup \"apps/v1\" \"DaemonSet\" \"\
-                openshift-dns\" \"node-resolver\").spec.template.spec.containers 0).image\
-                \ }}'\n              imagePullPolicy: IfNotPresent\n             \
-                \ command:\n                - python3\n                - /scripts/refresh.py\n\
-                \              volumeMounts:\n                - name: script\n   \
-                \               mountPath: /scripts\n                  readOnly: true\n\
-                \                - name: host-root\n                  mountPath: /host\n\
-                \                  readOnly: true\n              resources:\n    \
-                \            requests:\n                  cpu: 10m\n             \
-                \     memory: 64Mi\n                limits:\n                  cpu:\
-                \ 100m\n                  memory: 128Mi\n              securityContext:\n\
-                \                allowPrivilegeEscalation: false\n               \
-                \ capabilities:\n                  drop:\n                    - ALL\n\
-                \                seccompProfile:\n                  type: RuntimeDefault\n\
-                \          volumes:\n            - name: script\n              configMap:\n\
-                \                name: ecr-credential-refresh-script\n           \
-                \     defaultMode: 0755\n            - name: host-root\n         \
-                \     hostPath:\n                path: /\n                type: Directory\n"
+                \      activeDeadlineSeconds: 3600\n      template:\n        metadata:\n\
+                \          labels:\n            app: ecr-credential-refresh\n    \
+                \    spec:\n          serviceAccountName: ecr-credential-refresh\n\
+                \          restartPolicy: Never\n          nodeSelector:\n       \
+                \     node-role.kubernetes.io/worker: \"\"\n          tolerations:\n\
+                \            - operator: Exists\n          hostNetwork: true\n   \
+                \       dnsPolicy: Default\n          containers:\n            - name:\
+                \ refresh\n              # Dynamic lookup: get image from node-resolver\
+                \ DaemonSet\n              # This image is guaranteed to be cached\
+                \ on worker nodes\n              # Uses index function since ACM templates\
+                \ don't support bracket notation\n              image: '{{ (index\
+                \ (lookup \"apps/v1\" \"DaemonSet\" \"openshift-dns\" \"node-resolver\"\
+                ).spec.template.spec.containers 0).image }}'\n              imagePullPolicy:\
+                \ IfNotPresent\n              command:\n                - python3\n\
+                \                - /scripts/refresh.py\n              volumeMounts:\n\
+                \                - name: script\n                  mountPath: /scripts\n\
+                \                  readOnly: true\n                - name: host-root\n\
+                \                  mountPath: /host\n                  readOnly: true\n\
+                \              resources:\n                requests:\n           \
+                \       cpu: 10m\n                  memory: 64Mi\n               \
+                \ limits:\n                  cpu: 100m\n                  memory:\
+                \ 128Mi\n              securityContext:\n                allowPrivilegeEscalation:\
+                \ false\n                capabilities:\n                  drop:\n\
+                \                    - ALL\n                seccompProfile:\n    \
+                \              type: RuntimeDefault\n          volumes:\n        \
+                \    - name: script\n              configMap:\n                name:\
+                \ ecr-credential-refresh-script\n                defaultMode: 0755\n\
+                \            - name: host-root\n              hostPath:\n        \
+                \        path: /\n                type: Directory\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7104,27 +7104,30 @@ objects:
                 Failed to create secret: {result.stderr}\")\n                log(f\"\
                 Successfully created {SECRET_NAME}\")\n\n            for registry\
                 \ in registries:\n                log(f\"  - {registry}\")\n\n\n \
-                \       def main():\n            # Step 1: Discover all ECR registries\
-                \ from IDMS\n            registries = discover_ecr_registries()\n\
-                \            if not registries:\n                log(\"Skipping -\
-                \ no ECR IDMS mirrors found (not a zero-egress cluster)\")\n     \
-                \           return\n\n            log(f\"Starting ECR credential refresh\
-                \ for {len(registries)} registry(s)\")\n\n            # Step 2: Get\
-                \ ECR token (same token works for all registries)\n            ecr_password\
-                \ = get_ecr_token(registries[0])\n\n            # Step 3: Update the\
-                \ secret with auth entries for all registries\n            update_secret(registries,\
-                \ ecr_password)\n\n            log(\"ECR credential refresh completed\
-                \ successfully\")\n\n\n        if __name__ == \"__main__\":\n    \
-                \        try:\n                main()\n            except Exception\
-                \ as e:\n                log(f\"FATAL - {e}\")\n                sys.exit(1)\n\
-                - complianceType: mustonlyhave\n  metadataComplianceType: musthave\n\
-                \  objectDefinition:\n    apiVersion: batch/v1\n    kind: CronJob\n\
-                \    metadata:\n      name: ecr-credential-refresh\n      namespace:\
-                \ kube-system\n      labels:\n        app: ecr-credential-refresh\n\
-                \    spec:\n      schedule: \"0 */4 * * *\"\n      concurrencyPolicy:\
-                \ Forbid\n      successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
+                \       def main():\n            jitter = int.from_bytes(os.urandom(2),\
+                \ \"big\") % 601\n            log(f\"Sleeping {jitter}s for jitter\"\
+                )\n            subprocess.run([\"sleep\", str(jitter)], check=True)\n\
+                \n            # Step 1: Discover all ECR registries from IDMS\n  \
+                \          registries = discover_ecr_registries()\n            if\
+                \ not registries:\n                log(\"Skipping - no ECR IDMS mirrors\
+                \ found (not a zero-egress cluster)\")\n                return\n\n\
+                \            log(f\"Starting ECR credential refresh for {len(registries)}\
+                \ registry(s)\")\n\n            # Step 2: Get ECR token (same token\
+                \ works for all registries)\n            ecr_password = get_ecr_token(registries[0])\n\
+                \n            # Step 3: Update the secret with auth entries for all\
+                \ registries\n            update_secret(registries, ecr_password)\n\
+                \n            log(\"ECR credential refresh completed successfully\"\
+                )\n\n\n        if __name__ == \"__main__\":\n            try:\n  \
+                \              main()\n            except Exception as e:\n      \
+                \          log(f\"FATAL - {e}\")\n                sys.exit(1)\n- complianceType:\
+                \ mustonlyhave\n  metadataComplianceType: musthave\n  objectDefinition:\n\
+                \    apiVersion: batch/v1\n    kind: CronJob\n    metadata:\n    \
+                \  name: ecr-credential-refresh\n      namespace: kube-system\n  \
+                \    labels:\n        app: ecr-credential-refresh\n    spec:\n   \
+                \   schedule: \"0 */5 * * *\"\n      concurrencyPolicy: Forbid\n \
+                \     successfulJobsHistoryLimit: 3\n      failedJobsHistoryLimit:\
                 \ 3\n      jobTemplate:\n        spec:\n          backoffLimit: 3\n\
-                \          activeDeadlineSeconds: 300\n          template:\n     \
+                \          activeDeadlineSeconds: 900\n          template:\n     \
                 \       metadata:\n              labels:\n                app: ecr-credential-refresh\n\
                 \            spec:\n              serviceAccountName: ecr-credential-refresh\n\
                 \              restartPolicy: OnFailure\n              nodeSelector:\n\


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / why we need it?

Fixes unnecessary kubelet restarts on ROSA HCP zero-egress 4.18+ clusters caused by the ECR credential refresh mechanism.

Two changes:

- Extend CronJob interval from 4h to 5h with a 0–10m random jitter.
  - ECR tokens are valid for 12 hours (fixed by AWS).
  - 5 hours still provides 2+ refreshes per token lifetime
  - The jitter staggers credential refreshes to minimize impact of kubelet restarts.
- Remove ttlSecondsAfterFinished from the initial one-shot job
  - #2631 incorrectly added this, the correct solution was  #2685 which set `restartPolicy: Never`
  - With ttlSecondsAfterFinished set, the completed Job gets deleted after 1h, so ACM recreates it on its next compliance eval (2h cycle), causing the initial Job to run repeatedly.
  - Removing the TTL lets the completed Job persist so ACM stays compliant and the Job runs only once.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://redhat.atlassian.net/browse/ROSAENG-65557

### Special notes for your reviewer:
- tested `restartPolicy` to `Never` does in fact retain pods for us
- tested the CronJob script changes by disabling ACM reconciliation, patching the ConfigMap and invoking a manual CronJob run:
```
2026-08-21 16:10:34 - Sleeping 244s for jitter
2026-08-21 16:14:38 - Discovering ECR registries from cluster configuration...
2026-08-21 16:14:39 - Discovered ECR registry: 122610517469.dkr.ecr.us-west-2.amazonaws.com
2026-08-21 16:14:39 - Found 1 unique ECR registry(s)
2026-08-21 16:14:39 - Starting ECR credential refresh for 1 registry(s)
2026-08-21 16:14:39 - Getting ECR authorization token via credential helper...
2026-08-21 16:14:40 - Successfully retrieved ECR authorization token
2026-08-21 16:14:40 - Updating additional-pull-secret in kube-system with 1 registry(s)...
2026-08-21 16:14:44 - Successfully patched additional-pull-secret (merged with existing entries)
2026-08-21 16:14:44 -   - 122610517469.dkr.ecr.us-west-2.amazonaws.com
2026-08-21 16:14:44 - ECR credential refresh completed successfully
```
- changes to remove systemd timer based refresh job have not yet been removed via app-interface. That will be done per-environment with at least 24h soak periods with testing

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of container registry credential refreshes by adding a randomized startup delay of up to 10 minutes.
  - Increased the refresh job’s execution window from 5 to 15 minutes.

- **Changes**
  - Credential refreshes now run every five hours instead of every four hours.
  - Initial refresh jobs no longer use an automatic expiration setting after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->