### PR TITLE
feat(ROSAENG-65780): add CronJob to cleanup orphaned Velero schedules and stuck backups

### DIFF
--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/01-serviceaccount.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/01-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/02-clusterrole.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/02-clusterrole.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+rules:
+# HostedCluster - existence check only, never modified. Cluster-scoped
+# because HostedClusters live in per-cluster namespaces across the MC,
+# not just openshift-adp.
+- apiGroups: [hypershift.openshift.io]
+  resources: [hostedclusters]
+  verbs: [get, list]

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/02-role.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/02-role.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp
+rules:
+# Schedule - evaluate and delete orphaned schedules
+- apiGroups: [velero.io]
+  resources: [schedules]
+  verbs: [get, list, delete]
+# Backup - evaluate and delete FailedValidation backups by exact name
+- apiGroups: [velero.io]
+  resources: [backups]
+  verbs: [get, list, delete]
+# BackupStorageLocation - existence check only, never modified
+- apiGroups: [velero.io]
+  resources: [backupstoragelocations]
+  verbs: [get, list]

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/03-clusterrolebinding.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/03-clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+subjects:
+- kind: ServiceAccount
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oadp-orphaned-schedule-cleanup

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/03-rolebinding.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/03-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp
+subjects:
+- kind: ServiceAccount
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: oadp-orphaned-schedule-cleanup

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/10-cronjob.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/10-cronjob.yaml
@@ -1,0 +1,320 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: oadp-orphaned-schedule-cleanup
+  namespace: openshift-adp
+spec:
+  schedule: "0 3 * * *"  # 03:00 UTC daily
+  suspend: false
+  concurrencyPolicy: Forbid  # Don't run if previous still running
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 604800  # Auto-delete Job after 7 days
+      backoffLimit: 0  # Don't retry on failure
+      activeDeadlineSeconds: 3600  # Bound total Job runtime; a blocked oc
+                                   # call must not keep the Job (and thus
+                                   # concurrencyPolicy: Forbid) active
+                                   # indefinitely and block future runs.
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          containers:
+          - name: cleanup
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                - ALL
+            resources:
+              requests:
+                memory: "100Mi"
+                cpu: "100m"
+              limits:
+                memory: "512Mi"
+                cpu: "500m"
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            env:
+            - name: HOME
+              value: /tmp
+            - name: TMPDIR
+              value: /tmp
+            command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+
+              NAMESPACE="openshift-adp"
+
+              echo "=============================================="
+              echo "  OADP Orphaned Schedule Cleanup Job"
+              echo "=============================================="
+              echo ""
+              echo "Start time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+              echo ""
+
+              # ============================================
+              # Gather Data
+              # ============================================
+              echo "Gathering Kubernetes data..."
+
+              # Fail closed: if we can't reliably list Schedules or Backups,
+              # abort rather than proceeding with an empty/partial inventory,
+              # which could otherwise cause an owned Schedule (or its
+              # backups) to be mistaken for absent/orphaned.
+              if ! SCHEDULES_JSON=$(oc get schedules -n "$NAMESPACE" --request-timeout=30s -o json 2>/dev/null); then
+                  echo "ERROR: failed to list Schedules in $NAMESPACE; aborting (fail-closed)." >&2
+                  exit 1
+              fi
+              if ! BACKUPS_JSON=$(oc get backups -n "$NAMESPACE" --request-timeout=30s -o json 2>/dev/null); then
+                  echo "ERROR: failed to list Backups in $NAMESPACE; aborting (fail-closed)." >&2
+                  exit 1
+              fi
+
+              SCHEDULE_COUNT=$(echo "$SCHEDULES_JSON" | jq '.items | length')
+              FAILED_VALIDATION_COUNT=$(echo "$BACKUPS_JSON" | jq '[.items[] | select(.status.phase == "FailedValidation")] | length')
+
+              echo "  Schedules found:            $SCHEDULE_COUNT"
+              echo "  FailedValidation backups:   $FAILED_VALIDATION_COUNT"
+              echo ""
+
+              if [ "$SCHEDULE_COUNT" = "0" ] && [ "$FAILED_VALIDATION_COUNT" = "0" ]; then
+                  echo "Nothing to evaluate. Exiting."
+                  echo "End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+                  exit 0
+              fi
+
+              # ============================================
+              # Build candidate schedule name list
+              # (union of existing Schedule names + schedule-name
+              #  labels referenced by FailedValidation backups,
+              #  covering the case where the Schedule itself is
+              #  already gone but orphaned backups remain)
+              # ============================================
+              SCHEDULE_NAMES_FROM_SCHEDULES=$(echo "$SCHEDULES_JSON" | jq -r '.items[].metadata.name')
+              SCHEDULE_NAMES_FROM_BACKUPS=$(echo "$BACKUPS_JSON" | jq -r \
+                  '[.items[] | select(.status.phase == "FailedValidation") | (.metadata.labels["velero.io/schedule-name"] // empty)] | unique[]')
+
+              UNLABELED_FV_COUNT=$(echo "$BACKUPS_JSON" | jq \
+                  '[.items[] | select(.status.phase == "FailedValidation") | select((.metadata.labels["velero.io/schedule-name"] // "") == "")] | length')
+
+              CANDIDATES=$(printf '%s\n%s\n' "$SCHEDULE_NAMES_FROM_SCHEDULES" "$SCHEDULE_NAMES_FROM_BACKUPS" | grep -v '^$' | sort -u || true)
+              CANDIDATE_COUNT=$(echo "$CANDIDATES" | grep -c . 2>/dev/null || true); CANDIDATE_COUNT=${CANDIDATE_COUNT:-0}
+
+              echo "  Candidate schedules to evaluate:                    $CANDIDATE_COUNT"
+              echo "  FailedValidation backups without schedule-name label (always skipped): $UNLABELED_FV_COUNT"
+              echo ""
+
+              # Note: individual Backup names are intentionally not logged
+              # here (see "No resource names in logs" in the README) - the
+              # aggregate count above is the signal; inspect the live
+              # cluster for specifics if manual review is needed.
+
+              DELETED_SCHEDULES=0
+              FAILED_SCHEDULES=0
+              DELETED_BACKUPS=0
+              FAILED_BACKUPS=0
+              SKIPPED_HC_EXISTS=0
+              SKIPPED_BSL_EXISTS=0
+              SKIPPED_OWNED=0
+              SKIPPED_UNPARSEABLE=0
+              SKIPPED_STATIC=0
+              SKIPPED_LOOKUP_ERROR=0
+
+              if [ "$CANDIDATE_COUNT" = "0" ]; then
+                  echo "  No candidate schedules to evaluate."
+              else
+                  IDX=0
+                  while read -r name; do
+                      [ -z "$name" ] && continue
+                      IDX=$((IDX + 1))
+                      echo "[$IDX/$CANDIDATE_COUNT] Evaluating candidate schedule"
+
+                      # Static, cluster-agnostic schedules (e.g.
+                      # daily-full-backup, weekly-full-backup) are permanent
+                      # infrastructure, never orphans. Ignore them quietly -
+                      # they do not need manual review.
+                      if [[ "$name" == *-full-backup ]]; then
+                          echo "    SKIP: static schedule (ignored)"
+                          SKIPPED_STATIC=$((SKIPPED_STATIC + 1))
+                          sleep 0.2
+                          continue
+                      fi
+
+                      # Parse CLUSTER_ID from the schedule name (convention:
+                      # <cluster-id>-hourly, cluster ID is a 26-32 char
+                      # lowercase alphanumeric string). Conservative: skip
+                      # and report anything that doesn't confidently match
+                      # rather than guessing at a cluster ID.
+                      if [[ "$name" =~ ^([a-z0-9]{26,32})-hourly$ ]]; then
+                          CLUSTER_ID="${BASH_REMATCH[1]}"
+                      else
+                          echo "    SKIP: could not parse cluster ID from schedule name (manual review needed)"
+                          SKIPPED_UNPARSEABLE=$((SKIPPED_UNPARSEABLE + 1))
+                          sleep 0.2
+                          continue
+                      fi
+
+                      # Fail-closed: an oc lookup error must NOT be read as
+                      # "HostedCluster absent" (which would also produce
+                      # empty output). Capture output only on success; on
+                      # any error, skip this candidate for manual review
+                      # rather than risking a false-positive deletion.
+                      if HC_OUTPUT=$(oc get hc -A -l "api.openshift.com/id=${CLUSTER_ID}" \
+                          --no-headers --request-timeout=30s 2>/dev/null); then
+                          HC_COUNT=$(printf '%s' "$HC_OUTPUT" | grep -c . || true)
+                      else
+                          echo "    SKIP: could not confirm HostedCluster absence (lookup error; manual review needed)"
+                          SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR + 1))
+                          sleep 0.2
+                          continue
+                      fi
+                      if [ "$HC_COUNT" != "0" ]; then
+                          echo "    SKIP: HostedCluster still exists for the parsed cluster ID"
+                          SKIPPED_HC_EXISTS=$((SKIPPED_HC_EXISTS + 1))
+                          sleep 0.2
+                          continue
+                      fi
+
+                      # Distinguish a confirmed-absent BSL (NotFound) from an
+                      # actual lookup error (e.g. transient API issue). Only
+                      # a confirmed NotFound is treated as "BSL absent" -
+                      # any other error is conservatively skipped rather
+                      # than assumed absent.
+                      # Note: BSL_OUTPUT (the raw oc error/output) is
+                      # intentionally never logged - only a generic,
+                      # bounded status message is emitted (see "No
+                      # resource names in logs" in the README).
+                      if BSL_OUTPUT=$(oc get backupstoragelocation "$name" -n "$NAMESPACE" --request-timeout=30s -o name 2>&1); then
+                          echo "    SKIP: BackupStorageLocation still exists"
+                          SKIPPED_BSL_EXISTS=$((SKIPPED_BSL_EXISTS + 1))
+                          sleep 0.2
+                          continue
+                      elif ! echo "$BSL_OUTPUT" | grep -qi "NotFound"; then
+                          echo "    SKIP: could not confirm BackupStorageLocation absence (lookup error; manual review needed)"
+                          SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR + 1))
+                          sleep 0.2
+                          continue
+                      fi
+
+                      SCHEDULE_EXISTS=$(echo "$SCHEDULES_JSON" | jq --arg n "$name" '[.items[] | select(.metadata.name == $n)] | length')
+                      if [ "$SCHEDULE_EXISTS" != "0" ]; then
+                          OWNER_COUNT=$(echo "$SCHEDULES_JSON" | jq --arg n "$name" \
+                              '[.items[] | select(.metadata.name == $n) | (.metadata.ownerReferences // [])] | flatten | length')
+                          if [ "$OWNER_COUNT" != "0" ]; then
+                              echo "    SKIP: Schedule has ownerReferences; flagging for manual investigation"
+                              SKIPPED_OWNED=$((SKIPPED_OWNED + 1))
+                              sleep 0.2
+                              continue
+                          fi
+                      fi
+
+                      # Safe to clean up: HostedCluster gone, BSL gone, and
+                      # the Schedule (if present) has no ownerReferences.
+                      SAFE_TO_DELETE_BACKUPS=true
+                      if [ "$SCHEDULE_EXISTS" != "0" ]; then
+                          if oc delete schedule "$name" -n "$NAMESPACE" --request-timeout=30s --wait=false >/dev/null 2>&1; then
+                              echo "    OK:   deleted Schedule"
+                              DELETED_SCHEDULES=$((DELETED_SCHEDULES + 1))
+                          else
+                              echo "    FAIL: could not delete Schedule"
+                              FAILED_SCHEDULES=$((FAILED_SCHEDULES + 1))
+                              SAFE_TO_DELETE_BACKUPS=false
+                          fi
+                      else
+                          echo "    INFO: Schedule object already absent; cleaning orphaned backups only"
+                      fi
+
+                      # Do not delete this schedule's FailedValidation
+                      # backups if the Schedule itself failed to delete -
+                      # avoid removing Backups while a (possibly transient)
+                      # error left the Schedule in place; retry next run.
+                      if [ "$SAFE_TO_DELETE_BACKUPS" = "false" ]; then
+                          echo "    SKIP: not deleting FailedValidation backups because Schedule deletion failed"
+                          sleep 0.2
+                          continue
+                      fi
+
+                      # Delete FailedValidation backups for this schedule by
+                      # EXACT name only - never via a bare label selector,
+                      # since that would not be phase-aware and could match
+                      # backups in other phases (e.g. PartiallyFailed).
+                      BACKUP_NAMES=$(echo "$BACKUPS_JSON" | jq -r --arg n "$name" \
+                          '.items[] | select(.status.phase == "FailedValidation") | select(.metadata.labels["velero.io/schedule-name"] == $n) | .metadata.name')
+                      BACKUP_NAMES=${BACKUP_NAMES:-}
+                      if [ -n "$BACKUP_NAMES" ]; then
+                          while read -r bname; do
+                              [ -z "$bname" ] && continue
+                              if oc delete backup "$bname" -n "$NAMESPACE" --request-timeout=30s --wait=false >/dev/null 2>&1; then
+                                  echo "    OK:   deleted Backup"
+                                  DELETED_BACKUPS=$((DELETED_BACKUPS + 1))
+                              else
+                                  echo "    FAIL: could not delete Backup"
+                                  FAILED_BACKUPS=$((FAILED_BACKUPS + 1))
+                              fi
+                              sleep 0.2
+                          done <<< "$BACKUP_NAMES"
+                      fi
+
+                      sleep 0.2
+                  done <<< "$CANDIDATES"
+              fi
+
+              # ============================================
+              # Summary
+              # ============================================
+              echo ""
+              echo "=============================================="
+              echo "  CLEANUP COMPLETE"
+              echo "=============================================="
+              echo ""
+              echo "  Candidates evaluated:               $CANDIDATE_COUNT"
+              echo "  Schedules deleted:                  $DELETED_SCHEDULES  (failed: $FAILED_SCHEDULES)"
+              echo "  FailedValidation backups deleted:   $DELETED_BACKUPS  (failed: $FAILED_BACKUPS)"
+              echo "  Skipped - HostedCluster exists:     $SKIPPED_HC_EXISTS"
+              echo "  Skipped - BSL exists:               $SKIPPED_BSL_EXISTS"
+              echo "  Skipped - lookup error (HC/BSL):    $SKIPPED_LOOKUP_ERROR"
+              echo "  Skipped - Schedule has owners:      $SKIPPED_OWNED"
+              echo "  Skipped - unparseable cluster ID:   $SKIPPED_UNPARSEABLE"
+              echo "  Skipped - static schedule:          $SKIPPED_STATIC"
+              echo "  Skipped - unlabeled FV backups:     $UNLABELED_FV_COUNT"
+              echo ""
+              echo "  Total deleted:                      $((DELETED_SCHEDULES + DELETED_BACKUPS))"
+              echo "  Total failures:                     $((FAILED_SCHEDULES + FAILED_BACKUPS))"
+              echo ""
+              echo "End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+
+              # Fail the Job if any deletion failed, so partial cleanups
+              # are recorded as failed Jobs (visible via `oc get jobs`)
+              # rather than silently succeeding.
+              if [ "$FAILED_SCHEDULES" != "0" ] || [ "$FAILED_BACKUPS" != "0" ]; then
+                  exit 1
+              fi
+          volumes:
+          - name: tmp
+            emptyDir: {}
+          serviceAccountName: oadp-orphaned-schedule-cleanup
+          restartPolicy: Never

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/README.md
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/README.md
@@ -1,0 +1,162 @@
+# OADP Orphaned Schedule Cleanup CronJob
+
+Kubernetes CronJob to clean up orphaned Velero `Schedule` resources and their associated `FailedValidation` `Backup` resources on HyperShift Management Clusters.
+
+## Background
+
+This job implements the safe-cleanup recommendations from the `OADPBackupCRAccumulation` alert investigation runbook:
+
+- [OADPBackupCRAccumulation SOP](https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/oadp/OADPBackupCRAccumulation.md)
+
+The alert fires when more than 100 Velero `Backup` CRs sit in a non-terminal phase (`Failed`, `PartiallyFailed`, `FailedValidation`, `Finalizing`, `Deleting`) for over an hour in the `openshift-adp` namespace on an HCP management cluster. A common root cause is a per-HostedCluster backup `Schedule` that still references a `BackupStorageLocation` (BSL) which no longer exists (`BSLNotFound`) — typically because the HostedCluster itself has since been deleted and its BSL/Schedule were never cleaned up.
+
+## What This CronJob Does
+
+The job evaluates every candidate Schedule (existing Schedules, plus any Schedule name still referenced by a `FailedValidation` Backup's `velero.io/schedule-name` label even if the Schedule object itself is gone) against this decision matrix:
+
+| BSL exists? | Schedule exists? | Schedule has ownerReferences? | Action |
+|---|---|---|---|
+| Yes | — | — | **Skip** — not the BSLNotFound scenario; flag for manual review |
+| No | No | — (backups unlabeled) | **Skip** — cannot safely target with a phase-aware, exact-name delete |
+| No | No | — (backups labeled) | **Delete** the orphaned `FailedValidation` Backups only (no Schedule object to remove) |
+| No | Yes | Yes | **Skip** — flag for manual investigation, never delete owned Schedules |
+| No | Yes | No | **Delete** both the Schedule and its `FailedValidation` Backups |
+
+Additional safety rules enforced by the script:
+
+- **Static schedules are ignored**: any Schedule name matching `*-full-backup` (e.g. `daily-full-backup`, `weekly-full-backup`) is permanent, cluster-agnostic infrastructure, not a per-HostedCluster orphan candidate. These are quietly skipped up front and are **not** counted as needing manual review.
+- **Cluster ID parsing**: the `CLUSTER_ID` used to check for a live HostedCluster is parsed directly from the Schedule name (convention: `<cluster-id>-hourly`, where the cluster ID is a 26-32 character lowercase alphanumeric string). If a name doesn't confidently match this pattern (and isn't a static schedule per above), the job **skips it and reports it for manual review** rather than guessing.
+- **Exact-name deletes only**: Backup deletions always target explicit Backup CR names, never a bare `-l velero.io/schedule-name=<name>` label selector — that selector is not phase-aware and could otherwise catch backups in other non-terminal phases (e.g. `PartiallyFailed`) that must not be touched.
+- **Unlabeled backups are never deleted**: `FailedValidation` Backups with no `velero.io/schedule-name` label are always skipped and reported only.
+
+### Checks performed per candidate Schedule name
+
+| Step | Description |
+|------|-------------|
+| 1 | If the name matches `*-full-backup`, skip quietly (static schedule, not an orphan candidate) |
+| 2 | Parse `CLUSTER_ID` from the Schedule name; skip + report if unparseable |
+| 3 | `oc get hc -A -l "api.openshift.com/id=${CLUSTER_ID}"` — skip if the HostedCluster still exists |
+| 4 | `oc get backupstoragelocation ${SCHEDULE_NAME} -n openshift-adp` — skip if the BSL still exists; if the lookup fails for any reason other than a confirmed `NotFound`, skip and flag for manual review rather than assuming the BSL is absent |
+| 5 | If the Schedule object still exists, check `ownerReferences` — skip + flag if owned |
+| 6 | Delete the Schedule (if present); if that delete fails, skip Backup deletion for this candidate this run (retry next run) rather than deleting Backups out from under a Schedule that failed to delete |
+| 7 | Delete each matching `FailedValidation` Backup by exact name |
+
+### Summary
+
+The CronJob outputs a per-item log line (`OK`/`FAIL`/`SKIP`) plus a final summary with counts for each outcome category and grand totals. Per-item lines are intentionally generic — they never include Schedule/Backup names, cluster IDs, or raw `oc` error output (see [No resource names or cluster IDs in logs](#safety) below).
+
+## Deployment
+
+This CronJob is deployed via SelectorSyncSet to all non-FedRAMP Management Clusters (`ext-hypershift.openshift.io/cluster-type: management-cluster`, excluding clusters labeled `api.openshift.com/fedramp: "true"`).
+
+### Promotion Path
+
+1. **Integration** — Test on int MCs first
+2. **Stage** — Validate on staging MCs
+3. **Production** — Roll out to all prod MCs
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `01-serviceaccount.yaml` | ServiceAccount for the CronJob (in `openshift-adp` namespace) |
+| `02-clusterrole.yaml` | Cluster-scoped RBAC: HostedCluster get/list only (HostedClusters live outside `openshift-adp`) |
+| `02-role.yaml` | Namespaced RBAC (in `openshift-adp`): Schedule get/list/delete, Backup get/list/delete, BackupStorageLocation get/list |
+| `03-clusterrolebinding.yaml` | Binds the ClusterRole to the ServiceAccount |
+| `03-rolebinding.yaml` | Binds the namespaced Role to the ServiceAccount (in `openshift-adp`) |
+| `10-cronjob.yaml` | The cleanup CronJob (active by default, daily schedule, uses jq) |
+| `config.yaml` | SelectorSyncSet targeting MCs only |
+
+## Usage
+
+Unlike some other OADP cleanup jobs in this repo, this CronJob is deployed **active** (`suspend: false`) on a daily schedule (`0 3 * * *` UTC), since it only ever deletes resources that are already confirmed orphaned by both the HostedCluster-existence and BSL-existence checks.
+
+### Manual trigger
+
+Create a Job from the CronJob template — can be run at any time, independent of the schedule:
+
+```bash
+oc create job --from=cronjob/oadp-orphaned-schedule-cleanup manual-cleanup-$(date +%s) \
+  -n openshift-adp
+
+# Watch progress
+oc logs -n openshift-adp -f job/manual-cleanup-<timestamp>
+```
+
+### Pausing the schedule
+
+```bash
+oc patch cronjob oadp-orphaned-schedule-cleanup -n openshift-adp \
+  --type merge -p '{"spec":{"suspend":true}}'
+```
+
+### Resuming the schedule
+
+```bash
+oc patch cronjob oadp-orphaned-schedule-cleanup -n openshift-adp \
+  --type merge -p '{"spec":{"suspend":false}}'
+```
+
+## Monitoring
+
+```bash
+# List CronJob and spawned Jobs
+oc get cronjob,jobs -n openshift-adp
+
+# View logs from the most recent Job (selects the newest Job
+# explicitly - a bare `-l job-name` selector matches Pods from
+# every Job ever created by this CronJob, not just the latest)
+JOB=$(oc get jobs -n openshift-adp \
+  --sort-by=.metadata.creationTimestamp -o name | tail -1)
+oc logs -n openshift-adp "$JOB" --tail=200
+
+# View specific Job logs
+oc logs -n openshift-adp job/<job-name>
+```
+
+## Job History
+
+The CronJob keeps history of recent runs:
+- `successfulJobsHistoryLimit: 3` — Keeps last 3 successful Jobs
+- `failedJobsHistoryLimit: 3` — Keeps last 3 failed Jobs
+- `ttlSecondsAfterFinished: 604800` — Auto-deletes Jobs after 7 days
+
+## Troubleshooting
+
+### Re-execute if job hangs
+
+```bash
+# 1. Check running jobs
+oc get jobs -n openshift-adp | grep orphaned-schedule-cleanup
+
+# 2. Kill hung job (if needed)
+oc delete job <job-name> -n openshift-adp
+
+# 3. Trigger new run
+oc create job --from=cronjob/oadp-orphaned-schedule-cleanup manual-cleanup-$(date +%s) -n openshift-adp
+```
+
+## Safety
+
+- **Scoped**: only evaluates Velero `Schedule` and `FailedValidation` `Backup` resources in `openshift-adp`.
+- **Least-privilege RBAC**: Velero `Schedule`/`Backup`/`BackupStorageLocation` permissions are granted via a namespaced `Role`/`RoleBinding` scoped to `openshift-adp` only. The `ClusterRole`/`ClusterRoleBinding` grants nothing more than read-only `get`/`list` on `HostedCluster` (cluster-scoped, since HostedClusters live outside `openshift-adp`).
+- **Exact-name deletes**: Backups are always deleted by explicit name, never by a phase-unaware label selector.
+- **Static schedules are ignored**: names matching `*-full-backup` are quietly skipped up front and never flagged for manual review.
+- **Conservative cluster-ID parsing**: remaining schedules with a name that doesn't confidently match the expected `<cluster-id>-hourly` convention (26-32 character lowercase alphanumeric cluster ID) are skipped and reported rather than guessed at.
+- **Two independent existence checks required**: both the HostedCluster and the BackupStorageLocation must be confirmed absent before anything is deleted.
+- **Fail-closed inventory checks**: if the initial `oc get schedules`/`oc get backups` listing fails, the job aborts immediately instead of silently treating the failure as an empty inventory (which could otherwise misidentify owned Schedules or their Backups as orphaned).
+- **Fail-closed BSL check**: a BSL is only treated as absent on a confirmed `NotFound`; any other lookup error causes the candidate to be skipped and flagged rather than assumed absent.
+- **Schedule/Backup delete ordering**: Backups are only deleted after their Schedule has been successfully deleted (or was already absent). If a Schedule delete fails, its Backups are left alone that run and retried on the next scheduled run.
+- **Owned Schedules are never deleted**: Schedules with `ownerReferences` are always flagged for manual investigation instead.
+- **Unlabeled backups are never deleted**: reported for manual review only.
+- **No resource names or cluster IDs in logs**: per-item log lines emit only generic status classifications (e.g. `SKIP: BackupStorageLocation still exists`) and the final summary reports aggregate counts only. Schedule/Backup names, parsed cluster IDs, and raw `oc` lookup error output are never printed, so retained Job logs cannot leak internal identifiers or API error details. To investigate a specific skip/failure, query the live cluster directly (e.g. `oc get schedules,backups -n openshift-adp -o wide`).
+- **Idempotent**: safe to re-run; already-cleaned resources simply won't appear as candidates.
+- **Concurrency protection**: `concurrencyPolicy: Forbid` prevents overlapping runs.
+- **Resource limits**: the container defines both `requests` and `limits` (`memory: 512Mi`, `cpu: 500m`) to bound memory usage given the potentially large in-memory Schedule/Backup JSON inventories.
+- **Read-only root filesystem**: the container runs with `readOnlyRootFilesystem: true`; a writable `emptyDir` is mounted at `/tmp` (with `HOME`/`TMPDIR` pointed there) for any temporary files `oc`/`jq` need to write.
+- **History preserved**: previous Job logs can be reviewed via `oc get jobs` / `oc logs`.
+- **Fails visibly on partial cleanup**: if any Schedule or Backup deletion fails, the job exits non-zero and the Job is marked failed (visible via `oc get jobs`) rather than silently reporting success.
+
+## Related
+
+- SOP: [OADPBackupCRAccumulation](https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/oadp/OADPBackupCRAccumulation.md)

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/config.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/config.yaml
@@ -1,0 +1,10 @@
+# Deploy to HyperShift Management Clusters only
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30950,6 +30950,341 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-oadp-orphaned-schedule-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      rules:
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - hostedclusters
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      rules:
+      - apiGroups:
+        - velero.io
+        resources:
+        - schedules
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backups
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backupstoragelocations
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: oadp-orphaned-schedule-cleanup
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: oadp-orphaned-schedule-cleanup
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      spec:
+        schedule: 0 3 * * *
+        suspend: false
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 604800
+            backoffLimit: 0
+            activeDeadlineSeconds: 3600
+            template:
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: cleanup
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: IfNotPresent
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    capabilities:
+                      drop:
+                      - ALL
+                  resources:
+                    requests:
+                      memory: 100Mi
+                      cpu: 100m
+                    limits:
+                      memory: 512Mi
+                      cpu: 500m
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: /tmp
+                  env:
+                  - name: HOME
+                    value: /tmp
+                  - name: TMPDIR
+                    value: /tmp
+                  command:
+                  - bash
+                  - -c
+                  - "set -euo pipefail\n\nNAMESPACE=\"openshift-adp\"\n\necho \"==============================================\"\
+                    \necho \"  OADP Orphaned Schedule Cleanup Job\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"Start time: $(date -u '+%Y-%m-%d %H:%M:%S\
+                    \ UTC')\"\necho \"\"\n\n# ============================================\n\
+                    # Gather Data\n# ============================================\n\
+                    echo \"Gathering Kubernetes data...\"\n\n# Fail closed: if we\
+                    \ can't reliably list Schedules or Backups,\n# abort rather than\
+                    \ proceeding with an empty/partial inventory,\n# which could otherwise\
+                    \ cause an owned Schedule (or its\n# backups) to be mistaken for\
+                    \ absent/orphaned.\nif ! SCHEDULES_JSON=$(oc get schedules -n\
+                    \ \"$NAMESPACE\" --request-timeout=30s -o json 2>/dev/null); then\n\
+                    \    echo \"ERROR: failed to list Schedules in $NAMESPACE; aborting\
+                    \ (fail-closed).\" >&2\n    exit 1\nfi\nif ! BACKUPS_JSON=$(oc\
+                    \ get backups -n \"$NAMESPACE\" --request-timeout=30s -o json\
+                    \ 2>/dev/null); then\n    echo \"ERROR: failed to list Backups\
+                    \ in $NAMESPACE; aborting (fail-closed).\" >&2\n    exit 1\nfi\n\
+                    \nSCHEDULE_COUNT=$(echo \"$SCHEDULES_JSON\" | jq '.items | length')\n\
+                    FAILED_VALIDATION_COUNT=$(echo \"$BACKUPS_JSON\" | jq '[.items[]\
+                    \ | select(.status.phase == \"FailedValidation\")] | length')\n\
+                    \necho \"  Schedules found:            $SCHEDULE_COUNT\"\necho\
+                    \ \"  FailedValidation backups:   $FAILED_VALIDATION_COUNT\"\n\
+                    echo \"\"\n\nif [ \"$SCHEDULE_COUNT\" = \"0\" ] && [ \"$FAILED_VALIDATION_COUNT\"\
+                    \ = \"0\" ]; then\n    echo \"Nothing to evaluate. Exiting.\"\n\
+                    \    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\
+                    \    exit 0\nfi\n\n# ============================================\n\
+                    # Build candidate schedule name list\n# (union of existing Schedule\
+                    \ names + schedule-name\n#  labels referenced by FailedValidation\
+                    \ backups,\n#  covering the case where the Schedule itself is\n\
+                    #  already gone but orphaned backups remain)\n# ============================================\n\
+                    SCHEDULE_NAMES_FROM_SCHEDULES=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ -r '.items[].metadata.name')\nSCHEDULE_NAMES_FROM_BACKUPS=$(echo\
+                    \ \"$BACKUPS_JSON\" | jq -r \\\n    '[.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | (.metadata.labels[\"velero.io/schedule-name\"\
+                    ] // empty)] | unique[]')\n\nUNLABELED_FV_COUNT=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq \\\n    '[.items[] | select(.status.phase == \"FailedValidation\"\
+                    ) | select((.metadata.labels[\"velero.io/schedule-name\"] // \"\
+                    \") == \"\")] | length')\n\nCANDIDATES=$(printf '%s\\n%s\\n' \"\
+                    $SCHEDULE_NAMES_FROM_SCHEDULES\" \"$SCHEDULE_NAMES_FROM_BACKUPS\"\
+                    \ | grep -v '^$' | sort -u || true)\nCANDIDATE_COUNT=$(echo \"\
+                    $CANDIDATES\" | grep -c . 2>/dev/null || true); CANDIDATE_COUNT=${CANDIDATE_COUNT:-0}\n\
+                    \necho \"  Candidate schedules to evaluate:                  \
+                    \  $CANDIDATE_COUNT\"\necho \"  FailedValidation backups without\
+                    \ schedule-name label (always skipped): $UNLABELED_FV_COUNT\"\n\
+                    echo \"\"\n\n# Note: individual Backup names are intentionally\
+                    \ not logged\n# here (see \"No resource names in logs\" in the\
+                    \ README) - the\n# aggregate count above is the signal; inspect\
+                    \ the live\n# cluster for specifics if manual review is needed.\n\
+                    \nDELETED_SCHEDULES=0\nFAILED_SCHEDULES=0\nDELETED_BACKUPS=0\n\
+                    FAILED_BACKUPS=0\nSKIPPED_HC_EXISTS=0\nSKIPPED_BSL_EXISTS=0\n\
+                    SKIPPED_OWNED=0\nSKIPPED_UNPARSEABLE=0\nSKIPPED_STATIC=0\nSKIPPED_LOOKUP_ERROR=0\n\
+                    \nif [ \"$CANDIDATE_COUNT\" = \"0\" ]; then\n    echo \"  No candidate\
+                    \ schedules to evaluate.\"\nelse\n    IDX=0\n    while read -r\
+                    \ name; do\n        [ -z \"$name\" ] && continue\n        IDX=$((IDX\
+                    \ + 1))\n        echo \"[$IDX/$CANDIDATE_COUNT] Evaluating candidate\
+                    \ schedule\"\n\n        # Static, cluster-agnostic schedules (e.g.\n\
+                    \        # daily-full-backup, weekly-full-backup) are permanent\n\
+                    \        # infrastructure, never orphans. Ignore them quietly\
+                    \ -\n        # they do not need manual review.\n        if [[\
+                    \ \"$name\" == *-full-backup ]]; then\n            echo \"   \
+                    \ SKIP: static schedule (ignored)\"\n            SKIPPED_STATIC=$((SKIPPED_STATIC\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Parse CLUSTER_ID from the schedule name (convention:\n\
+                    \        # <cluster-id>-hourly, cluster ID is a 26-32 char\n \
+                    \       # lowercase alphanumeric string). Conservative: skip\n\
+                    \        # and report anything that doesn't confidently match\n\
+                    \        # rather than guessing at a cluster ID.\n        if [[\
+                    \ \"$name\" =~ ^([a-z0-9]{26,32})-hourly$ ]]; then\n         \
+                    \   CLUSTER_ID=\"${BASH_REMATCH[1]}\"\n        else\n        \
+                    \    echo \"    SKIP: could not parse cluster ID from schedule\
+                    \ name (manual review needed)\"\n            SKIPPED_UNPARSEABLE=$((SKIPPED_UNPARSEABLE\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Fail-closed: an oc lookup error must NOT be\
+                    \ read as\n        # \"HostedCluster absent\" (which would also\
+                    \ produce\n        # empty output). Capture output only on success;\
+                    \ on\n        # any error, skip this candidate for manual review\n\
+                    \        # rather than risking a false-positive deletion.\n  \
+                    \      if HC_OUTPUT=$(oc get hc -A -l \"api.openshift.com/id=${CLUSTER_ID}\"\
+                    \ \\\n            --no-headers --request-timeout=30s 2>/dev/null);\
+                    \ then\n            HC_COUNT=$(printf '%s' \"$HC_OUTPUT\" | grep\
+                    \ -c . || true)\n        else\n            echo \"    SKIP: could\
+                    \ not confirm HostedCluster absence (lookup error; manual review\
+                    \ needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n        if [ \"$HC_COUNT\" != \"0\" ]; then\n          \
+                    \  echo \"    SKIP: HostedCluster still exists for the parsed\
+                    \ cluster ID\"\n            SKIPPED_HC_EXISTS=$((SKIPPED_HC_EXISTS\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Distinguish a confirmed-absent BSL (NotFound)\
+                    \ from an\n        # actual lookup error (e.g. transient API issue).\
+                    \ Only\n        # a confirmed NotFound is treated as \"BSL absent\"\
+                    \ -\n        # any other error is conservatively skipped rather\n\
+                    \        # than assumed absent.\n        # Note: BSL_OUTPUT (the\
+                    \ raw oc error/output) is\n        # intentionally never logged\
+                    \ - only a generic,\n        # bounded status message is emitted\
+                    \ (see \"No\n        # resource names in logs\" in the README).\n\
+                    \        if BSL_OUTPUT=$(oc get backupstoragelocation \"$name\"\
+                    \ -n \"$NAMESPACE\" --request-timeout=30s -o name 2>&1); then\n\
+                    \            echo \"    SKIP: BackupStorageLocation still exists\"\
+                    \n            SKIPPED_BSL_EXISTS=$((SKIPPED_BSL_EXISTS + 1))\n\
+                    \            sleep 0.2\n            continue\n        elif ! echo\
+                    \ \"$BSL_OUTPUT\" | grep -qi \"NotFound\"; then\n            echo\
+                    \ \"    SKIP: could not confirm BackupStorageLocation absence\
+                    \ (lookup error; manual review needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        SCHEDULE_EXISTS=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ --arg n \"$name\" '[.items[] | select(.metadata.name == $n)]\
+                    \ | length')\n        if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n\
+                    \            OWNER_COUNT=$(echo \"$SCHEDULES_JSON\" | jq --arg\
+                    \ n \"$name\" \\\n                '[.items[] | select(.metadata.name\
+                    \ == $n) | (.metadata.ownerReferences // [])] | flatten | length')\n\
+                    \            if [ \"$OWNER_COUNT\" != \"0\" ]; then\n        \
+                    \        echo \"    SKIP: Schedule has ownerReferences; flagging\
+                    \ for manual investigation\"\n                SKIPPED_OWNED=$((SKIPPED_OWNED\
+                    \ + 1))\n                sleep 0.2\n                continue\n\
+                    \            fi\n        fi\n\n        # Safe to clean up: HostedCluster\
+                    \ gone, BSL gone, and\n        # the Schedule (if present) has\
+                    \ no ownerReferences.\n        SAFE_TO_DELETE_BACKUPS=true\n \
+                    \       if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n         \
+                    \   if oc delete schedule \"$name\" -n \"$NAMESPACE\" --request-timeout=30s\
+                    \ --wait=false >/dev/null 2>&1; then\n                echo \"\
+                    \    OK:   deleted Schedule\"\n                DELETED_SCHEDULES=$((DELETED_SCHEDULES\
+                    \ + 1))\n            else\n                echo \"    FAIL: could\
+                    \ not delete Schedule\"\n                FAILED_SCHEDULES=$((FAILED_SCHEDULES\
+                    \ + 1))\n                SAFE_TO_DELETE_BACKUPS=false\n      \
+                    \      fi\n        else\n            echo \"    INFO: Schedule\
+                    \ object already absent; cleaning orphaned backups only\"\n  \
+                    \      fi\n\n        # Do not delete this schedule's FailedValidation\n\
+                    \        # backups if the Schedule itself failed to delete -\n\
+                    \        # avoid removing Backups while a (possibly transient)\n\
+                    \        # error left the Schedule in place; retry next run.\n\
+                    \        if [ \"$SAFE_TO_DELETE_BACKUPS\" = \"false\" ]; then\n\
+                    \            echo \"    SKIP: not deleting FailedValidation backups\
+                    \ because Schedule deletion failed\"\n            sleep 0.2\n\
+                    \            continue\n        fi\n\n        # Delete FailedValidation\
+                    \ backups for this schedule by\n        # EXACT name only - never\
+                    \ via a bare label selector,\n        # since that would not be\
+                    \ phase-aware and could match\n        # backups in other phases\
+                    \ (e.g. PartiallyFailed).\n        BACKUP_NAMES=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq -r --arg n \"$name\" \\\n            '.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | select(.metadata.labels[\"velero.io/schedule-name\"\
+                    ] == $n) | .metadata.name')\n        BACKUP_NAMES=${BACKUP_NAMES:-}\n\
+                    \        if [ -n \"$BACKUP_NAMES\" ]; then\n            while\
+                    \ read -r bname; do\n                [ -z \"$bname\" ] && continue\n\
+                    \                if oc delete backup \"$bname\" -n \"$NAMESPACE\"\
+                    \ --request-timeout=30s --wait=false >/dev/null 2>&1; then\n \
+                    \                   echo \"    OK:   deleted Backup\"\n      \
+                    \              DELETED_BACKUPS=$((DELETED_BACKUPS + 1))\n    \
+                    \            else\n                    echo \"    FAIL: could\
+                    \ not delete Backup\"\n                    FAILED_BACKUPS=$((FAILED_BACKUPS\
+                    \ + 1))\n                fi\n                sleep 0.2\n     \
+                    \       done <<< \"$BACKUP_NAMES\"\n        fi\n\n        sleep\
+                    \ 0.2\n    done <<< \"$CANDIDATES\"\nfi\n\n# ============================================\n\
+                    # Summary\n# ============================================\necho\
+                    \ \"\"\necho \"==============================================\"\
+                    \necho \"  CLEANUP COMPLETE\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"  Candidates evaluated:               $CANDIDATE_COUNT\"\
+                    \necho \"  Schedules deleted:                  $DELETED_SCHEDULES\
+                    \  (failed: $FAILED_SCHEDULES)\"\necho \"  FailedValidation backups\
+                    \ deleted:   $DELETED_BACKUPS  (failed: $FAILED_BACKUPS)\"\necho\
+                    \ \"  Skipped - HostedCluster exists:     $SKIPPED_HC_EXISTS\"\
+                    \necho \"  Skipped - BSL exists:               $SKIPPED_BSL_EXISTS\"\
+                    \necho \"  Skipped - lookup error (HC/BSL):    $SKIPPED_LOOKUP_ERROR\"\
+                    \necho \"  Skipped - Schedule has owners:      $SKIPPED_OWNED\"\
+                    \necho \"  Skipped - unparseable cluster ID:   $SKIPPED_UNPARSEABLE\"\
+                    \necho \"  Skipped - static schedule:          $SKIPPED_STATIC\"\
+                    \necho \"  Skipped - unlabeled FV backups:     $UNLABELED_FV_COUNT\"\
+                    \necho \"\"\necho \"  Total deleted:                      $((DELETED_SCHEDULES\
+                    \ + DELETED_BACKUPS))\"\necho \"  Total failures:            \
+                    \         $((FAILED_SCHEDULES + FAILED_BACKUPS))\"\necho \"\"\n\
+                    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\n# Fail\
+                    \ the Job if any deletion failed, so partial cleanups\n# are recorded\
+                    \ as failed Jobs (visible via `oc get jobs`)\n# rather than silently\
+                    \ succeeding.\nif [ \"$FAILED_SCHEDULES\" != \"0\" ] || [ \"$FAILED_BACKUPS\"\
+                    \ != \"0\" ]; then\n    exit 1\nfi\n"
+                volumes:
+                - name: tmp
+                  emptyDir: {}
+                serviceAccountName: oadp-orphaned-schedule-cleanup
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-oadp-vsc-cleanup
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30950,6 +30950,341 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-oadp-orphaned-schedule-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      rules:
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - hostedclusters
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      rules:
+      - apiGroups:
+        - velero.io
+        resources:
+        - schedules
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backups
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backupstoragelocations
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: oadp-orphaned-schedule-cleanup
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: oadp-orphaned-schedule-cleanup
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      spec:
+        schedule: 0 3 * * *
+        suspend: false
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 604800
+            backoffLimit: 0
+            activeDeadlineSeconds: 3600
+            template:
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: cleanup
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: IfNotPresent
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    capabilities:
+                      drop:
+                      - ALL
+                  resources:
+                    requests:
+                      memory: 100Mi
+                      cpu: 100m
+                    limits:
+                      memory: 512Mi
+                      cpu: 500m
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: /tmp
+                  env:
+                  - name: HOME
+                    value: /tmp
+                  - name: TMPDIR
+                    value: /tmp
+                  command:
+                  - bash
+                  - -c
+                  - "set -euo pipefail\n\nNAMESPACE=\"openshift-adp\"\n\necho \"==============================================\"\
+                    \necho \"  OADP Orphaned Schedule Cleanup Job\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"Start time: $(date -u '+%Y-%m-%d %H:%M:%S\
+                    \ UTC')\"\necho \"\"\n\n# ============================================\n\
+                    # Gather Data\n# ============================================\n\
+                    echo \"Gathering Kubernetes data...\"\n\n# Fail closed: if we\
+                    \ can't reliably list Schedules or Backups,\n# abort rather than\
+                    \ proceeding with an empty/partial inventory,\n# which could otherwise\
+                    \ cause an owned Schedule (or its\n# backups) to be mistaken for\
+                    \ absent/orphaned.\nif ! SCHEDULES_JSON=$(oc get schedules -n\
+                    \ \"$NAMESPACE\" --request-timeout=30s -o json 2>/dev/null); then\n\
+                    \    echo \"ERROR: failed to list Schedules in $NAMESPACE; aborting\
+                    \ (fail-closed).\" >&2\n    exit 1\nfi\nif ! BACKUPS_JSON=$(oc\
+                    \ get backups -n \"$NAMESPACE\" --request-timeout=30s -o json\
+                    \ 2>/dev/null); then\n    echo \"ERROR: failed to list Backups\
+                    \ in $NAMESPACE; aborting (fail-closed).\" >&2\n    exit 1\nfi\n\
+                    \nSCHEDULE_COUNT=$(echo \"$SCHEDULES_JSON\" | jq '.items | length')\n\
+                    FAILED_VALIDATION_COUNT=$(echo \"$BACKUPS_JSON\" | jq '[.items[]\
+                    \ | select(.status.phase == \"FailedValidation\")] | length')\n\
+                    \necho \"  Schedules found:            $SCHEDULE_COUNT\"\necho\
+                    \ \"  FailedValidation backups:   $FAILED_VALIDATION_COUNT\"\n\
+                    echo \"\"\n\nif [ \"$SCHEDULE_COUNT\" = \"0\" ] && [ \"$FAILED_VALIDATION_COUNT\"\
+                    \ = \"0\" ]; then\n    echo \"Nothing to evaluate. Exiting.\"\n\
+                    \    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\
+                    \    exit 0\nfi\n\n# ============================================\n\
+                    # Build candidate schedule name list\n# (union of existing Schedule\
+                    \ names + schedule-name\n#  labels referenced by FailedValidation\
+                    \ backups,\n#  covering the case where the Schedule itself is\n\
+                    #  already gone but orphaned backups remain)\n# ============================================\n\
+                    SCHEDULE_NAMES_FROM_SCHEDULES=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ -r '.items[].metadata.name')\nSCHEDULE_NAMES_FROM_BACKUPS=$(echo\
+                    \ \"$BACKUPS_JSON\" | jq -r \\\n    '[.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | (.metadata.labels[\"velero.io/schedule-name\"\
+                    ] // empty)] | unique[]')\n\nUNLABELED_FV_COUNT=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq \\\n    '[.items[] | select(.status.phase == \"FailedValidation\"\
+                    ) | select((.metadata.labels[\"velero.io/schedule-name\"] // \"\
+                    \") == \"\")] | length')\n\nCANDIDATES=$(printf '%s\\n%s\\n' \"\
+                    $SCHEDULE_NAMES_FROM_SCHEDULES\" \"$SCHEDULE_NAMES_FROM_BACKUPS\"\
+                    \ | grep -v '^$' | sort -u || true)\nCANDIDATE_COUNT=$(echo \"\
+                    $CANDIDATES\" | grep -c . 2>/dev/null || true); CANDIDATE_COUNT=${CANDIDATE_COUNT:-0}\n\
+                    \necho \"  Candidate schedules to evaluate:                  \
+                    \  $CANDIDATE_COUNT\"\necho \"  FailedValidation backups without\
+                    \ schedule-name label (always skipped): $UNLABELED_FV_COUNT\"\n\
+                    echo \"\"\n\n# Note: individual Backup names are intentionally\
+                    \ not logged\n# here (see \"No resource names in logs\" in the\
+                    \ README) - the\n# aggregate count above is the signal; inspect\
+                    \ the live\n# cluster for specifics if manual review is needed.\n\
+                    \nDELETED_SCHEDULES=0\nFAILED_SCHEDULES=0\nDELETED_BACKUPS=0\n\
+                    FAILED_BACKUPS=0\nSKIPPED_HC_EXISTS=0\nSKIPPED_BSL_EXISTS=0\n\
+                    SKIPPED_OWNED=0\nSKIPPED_UNPARSEABLE=0\nSKIPPED_STATIC=0\nSKIPPED_LOOKUP_ERROR=0\n\
+                    \nif [ \"$CANDIDATE_COUNT\" = \"0\" ]; then\n    echo \"  No candidate\
+                    \ schedules to evaluate.\"\nelse\n    IDX=0\n    while read -r\
+                    \ name; do\n        [ -z \"$name\" ] && continue\n        IDX=$((IDX\
+                    \ + 1))\n        echo \"[$IDX/$CANDIDATE_COUNT] Evaluating candidate\
+                    \ schedule\"\n\n        # Static, cluster-agnostic schedules (e.g.\n\
+                    \        # daily-full-backup, weekly-full-backup) are permanent\n\
+                    \        # infrastructure, never orphans. Ignore them quietly\
+                    \ -\n        # they do not need manual review.\n        if [[\
+                    \ \"$name\" == *-full-backup ]]; then\n            echo \"   \
+                    \ SKIP: static schedule (ignored)\"\n            SKIPPED_STATIC=$((SKIPPED_STATIC\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Parse CLUSTER_ID from the schedule name (convention:\n\
+                    \        # <cluster-id>-hourly, cluster ID is a 26-32 char\n \
+                    \       # lowercase alphanumeric string). Conservative: skip\n\
+                    \        # and report anything that doesn't confidently match\n\
+                    \        # rather than guessing at a cluster ID.\n        if [[\
+                    \ \"$name\" =~ ^([a-z0-9]{26,32})-hourly$ ]]; then\n         \
+                    \   CLUSTER_ID=\"${BASH_REMATCH[1]}\"\n        else\n        \
+                    \    echo \"    SKIP: could not parse cluster ID from schedule\
+                    \ name (manual review needed)\"\n            SKIPPED_UNPARSEABLE=$((SKIPPED_UNPARSEABLE\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Fail-closed: an oc lookup error must NOT be\
+                    \ read as\n        # \"HostedCluster absent\" (which would also\
+                    \ produce\n        # empty output). Capture output only on success;\
+                    \ on\n        # any error, skip this candidate for manual review\n\
+                    \        # rather than risking a false-positive deletion.\n  \
+                    \      if HC_OUTPUT=$(oc get hc -A -l \"api.openshift.com/id=${CLUSTER_ID}\"\
+                    \ \\\n            --no-headers --request-timeout=30s 2>/dev/null);\
+                    \ then\n            HC_COUNT=$(printf '%s' \"$HC_OUTPUT\" | grep\
+                    \ -c . || true)\n        else\n            echo \"    SKIP: could\
+                    \ not confirm HostedCluster absence (lookup error; manual review\
+                    \ needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n        if [ \"$HC_COUNT\" != \"0\" ]; then\n          \
+                    \  echo \"    SKIP: HostedCluster still exists for the parsed\
+                    \ cluster ID\"\n            SKIPPED_HC_EXISTS=$((SKIPPED_HC_EXISTS\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Distinguish a confirmed-absent BSL (NotFound)\
+                    \ from an\n        # actual lookup error (e.g. transient API issue).\
+                    \ Only\n        # a confirmed NotFound is treated as \"BSL absent\"\
+                    \ -\n        # any other error is conservatively skipped rather\n\
+                    \        # than assumed absent.\n        # Note: BSL_OUTPUT (the\
+                    \ raw oc error/output) is\n        # intentionally never logged\
+                    \ - only a generic,\n        # bounded status message is emitted\
+                    \ (see \"No\n        # resource names in logs\" in the README).\n\
+                    \        if BSL_OUTPUT=$(oc get backupstoragelocation \"$name\"\
+                    \ -n \"$NAMESPACE\" --request-timeout=30s -o name 2>&1); then\n\
+                    \            echo \"    SKIP: BackupStorageLocation still exists\"\
+                    \n            SKIPPED_BSL_EXISTS=$((SKIPPED_BSL_EXISTS + 1))\n\
+                    \            sleep 0.2\n            continue\n        elif ! echo\
+                    \ \"$BSL_OUTPUT\" | grep -qi \"NotFound\"; then\n            echo\
+                    \ \"    SKIP: could not confirm BackupStorageLocation absence\
+                    \ (lookup error; manual review needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        SCHEDULE_EXISTS=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ --arg n \"$name\" '[.items[] | select(.metadata.name == $n)]\
+                    \ | length')\n        if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n\
+                    \            OWNER_COUNT=$(echo \"$SCHEDULES_JSON\" | jq --arg\
+                    \ n \"$name\" \\\n                '[.items[] | select(.metadata.name\
+                    \ == $n) | (.metadata.ownerReferences // [])] | flatten | length')\n\
+                    \            if [ \"$OWNER_COUNT\" != \"0\" ]; then\n        \
+                    \        echo \"    SKIP: Schedule has ownerReferences; flagging\
+                    \ for manual investigation\"\n                SKIPPED_OWNED=$((SKIPPED_OWNED\
+                    \ + 1))\n                sleep 0.2\n                continue\n\
+                    \            fi\n        fi\n\n        # Safe to clean up: HostedCluster\
+                    \ gone, BSL gone, and\n        # the Schedule (if present) has\
+                    \ no ownerReferences.\n        SAFE_TO_DELETE_BACKUPS=true\n \
+                    \       if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n         \
+                    \   if oc delete schedule \"$name\" -n \"$NAMESPACE\" --request-timeout=30s\
+                    \ --wait=false >/dev/null 2>&1; then\n                echo \"\
+                    \    OK:   deleted Schedule\"\n                DELETED_SCHEDULES=$((DELETED_SCHEDULES\
+                    \ + 1))\n            else\n                echo \"    FAIL: could\
+                    \ not delete Schedule\"\n                FAILED_SCHEDULES=$((FAILED_SCHEDULES\
+                    \ + 1))\n                SAFE_TO_DELETE_BACKUPS=false\n      \
+                    \      fi\n        else\n            echo \"    INFO: Schedule\
+                    \ object already absent; cleaning orphaned backups only\"\n  \
+                    \      fi\n\n        # Do not delete this schedule's FailedValidation\n\
+                    \        # backups if the Schedule itself failed to delete -\n\
+                    \        # avoid removing Backups while a (possibly transient)\n\
+                    \        # error left the Schedule in place; retry next run.\n\
+                    \        if [ \"$SAFE_TO_DELETE_BACKUPS\" = \"false\" ]; then\n\
+                    \            echo \"    SKIP: not deleting FailedValidation backups\
+                    \ because Schedule deletion failed\"\n            sleep 0.2\n\
+                    \            continue\n        fi\n\n        # Delete FailedValidation\
+                    \ backups for this schedule by\n        # EXACT name only - never\
+                    \ via a bare label selector,\n        # since that would not be\
+                    \ phase-aware and could match\n        # backups in other phases\
+                    \ (e.g. PartiallyFailed).\n        BACKUP_NAMES=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq -r --arg n \"$name\" \\\n            '.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | select(.metadata.labels[\"velero.io/schedule-name\"\
+                    ] == $n) | .metadata.name')\n        BACKUP_NAMES=${BACKUP_NAMES:-}\n\
+                    \        if [ -n \"$BACKUP_NAMES\" ]; then\n            while\
+                    \ read -r bname; do\n                [ -z \"$bname\" ] && continue\n\
+                    \                if oc delete backup \"$bname\" -n \"$NAMESPACE\"\
+                    \ --request-timeout=30s --wait=false >/dev/null 2>&1; then\n \
+                    \                   echo \"    OK:   deleted Backup\"\n      \
+                    \              DELETED_BACKUPS=$((DELETED_BACKUPS + 1))\n    \
+                    \            else\n                    echo \"    FAIL: could\
+                    \ not delete Backup\"\n                    FAILED_BACKUPS=$((FAILED_BACKUPS\
+                    \ + 1))\n                fi\n                sleep 0.2\n     \
+                    \       done <<< \"$BACKUP_NAMES\"\n        fi\n\n        sleep\
+                    \ 0.2\n    done <<< \"$CANDIDATES\"\nfi\n\n# ============================================\n\
+                    # Summary\n# ============================================\necho\
+                    \ \"\"\necho \"==============================================\"\
+                    \necho \"  CLEANUP COMPLETE\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"  Candidates evaluated:               $CANDIDATE_COUNT\"\
+                    \necho \"  Schedules deleted:                  $DELETED_SCHEDULES\
+                    \  (failed: $FAILED_SCHEDULES)\"\necho \"  FailedValidation backups\
+                    \ deleted:   $DELETED_BACKUPS  (failed: $FAILED_BACKUPS)\"\necho\
+                    \ \"  Skipped - HostedCluster exists:     $SKIPPED_HC_EXISTS\"\
+                    \necho \"  Skipped - BSL exists:               $SKIPPED_BSL_EXISTS\"\
+                    \necho \"  Skipped - lookup error (HC/BSL):    $SKIPPED_LOOKUP_ERROR\"\
+                    \necho \"  Skipped - Schedule has owners:      $SKIPPED_OWNED\"\
+                    \necho \"  Skipped - unparseable cluster ID:   $SKIPPED_UNPARSEABLE\"\
+                    \necho \"  Skipped - static schedule:          $SKIPPED_STATIC\"\
+                    \necho \"  Skipped - unlabeled FV backups:     $UNLABELED_FV_COUNT\"\
+                    \necho \"\"\necho \"  Total deleted:                      $((DELETED_SCHEDULES\
+                    \ + DELETED_BACKUPS))\"\necho \"  Total failures:            \
+                    \         $((FAILED_SCHEDULES + FAILED_BACKUPS))\"\necho \"\"\n\
+                    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\n# Fail\
+                    \ the Job if any deletion failed, so partial cleanups\n# are recorded\
+                    \ as failed Jobs (visible via `oc get jobs`)\n# rather than silently\
+                    \ succeeding.\nif [ \"$FAILED_SCHEDULES\" != \"0\" ] || [ \"$FAILED_BACKUPS\"\
+                    \ != \"0\" ]; then\n    exit 1\nfi\n"
+                volumes:
+                - name: tmp
+                  emptyDir: {}
+                serviceAccountName: oadp-orphaned-schedule-cleanup
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-oadp-vsc-cleanup
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30950,6 +30950,341 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-oadp-orphaned-schedule-cleanup
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      rules:
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - hostedclusters
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      rules:
+      - apiGroups:
+        - velero.io
+        resources:
+        - schedules
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backups
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - velero.io
+        resources:
+        - backupstoragelocations
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: oadp-orphaned-schedule-cleanup
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      subjects:
+      - kind: ServiceAccount
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: oadp-orphaned-schedule-cleanup
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: oadp-orphaned-schedule-cleanup
+        namespace: openshift-adp
+      spec:
+        schedule: 0 3 * * *
+        suspend: false
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 604800
+            backoffLimit: 0
+            activeDeadlineSeconds: 3600
+            template:
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: cleanup
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: IfNotPresent
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    capabilities:
+                      drop:
+                      - ALL
+                  resources:
+                    requests:
+                      memory: 100Mi
+                      cpu: 100m
+                    limits:
+                      memory: 512Mi
+                      cpu: 500m
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: /tmp
+                  env:
+                  - name: HOME
+                    value: /tmp
+                  - name: TMPDIR
+                    value: /tmp
+                  command:
+                  - bash
+                  - -c
+                  - "set -euo pipefail\n\nNAMESPACE=\"openshift-adp\"\n\necho \"==============================================\"\
+                    \necho \"  OADP Orphaned Schedule Cleanup Job\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"Start time: $(date -u '+%Y-%m-%d %H:%M:%S\
+                    \ UTC')\"\necho \"\"\n\n# ============================================\n\
+                    # Gather Data\n# ============================================\n\
+                    echo \"Gathering Kubernetes data...\"\n\n# Fail closed: if we\
+                    \ can't reliably list Schedules or Backups,\n# abort rather than\
+                    \ proceeding with an empty/partial inventory,\n# which could otherwise\
+                    \ cause an owned Schedule (or its\n# backups) to be mistaken for\
+                    \ absent/orphaned.\nif ! SCHEDULES_JSON=$(oc get schedules -n\
+                    \ \"$NAMESPACE\" --request-timeout=30s -o json 2>/dev/null); then\n\
+                    \    echo \"ERROR: failed to list Schedules in $NAMESPACE; aborting\
+                    \ (fail-closed).\" >&2\n    exit 1\nfi\nif ! BACKUPS_JSON=$(oc\
+                    \ get backups -n \"$NAMESPACE\" --request-timeout=30s -o json\
+                    \ 2>/dev/null); then\n    echo \"ERROR: failed to list Backups\
+                    \ in $NAMESPACE; aborting (fail-closed).\" >&2\n    exit 1\nfi\n\
+                    \nSCHEDULE_COUNT=$(echo \"$SCHEDULES_JSON\" | jq '.items | length')\n\
+                    FAILED_VALIDATION_COUNT=$(echo \"$BACKUPS_JSON\" | jq '[.items[]\
+                    \ | select(.status.phase == \"FailedValidation\")] | length')\n\
+                    \necho \"  Schedules found:            $SCHEDULE_COUNT\"\necho\
+                    \ \"  FailedValidation backups:   $FAILED_VALIDATION_COUNT\"\n\
+                    echo \"\"\n\nif [ \"$SCHEDULE_COUNT\" = \"0\" ] && [ \"$FAILED_VALIDATION_COUNT\"\
+                    \ = \"0\" ]; then\n    echo \"Nothing to evaluate. Exiting.\"\n\
+                    \    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\
+                    \    exit 0\nfi\n\n# ============================================\n\
+                    # Build candidate schedule name list\n# (union of existing Schedule\
+                    \ names + schedule-name\n#  labels referenced by FailedValidation\
+                    \ backups,\n#  covering the case where the Schedule itself is\n\
+                    #  already gone but orphaned backups remain)\n# ============================================\n\
+                    SCHEDULE_NAMES_FROM_SCHEDULES=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ -r '.items[].metadata.name')\nSCHEDULE_NAMES_FROM_BACKUPS=$(echo\
+                    \ \"$BACKUPS_JSON\" | jq -r \\\n    '[.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | (.metadata.labels[\"velero.io/schedule-name\"\
+                    ] // empty)] | unique[]')\n\nUNLABELED_FV_COUNT=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq \\\n    '[.items[] | select(.status.phase == \"FailedValidation\"\
+                    ) | select((.metadata.labels[\"velero.io/schedule-name\"] // \"\
+                    \") == \"\")] | length')\n\nCANDIDATES=$(printf '%s\\n%s\\n' \"\
+                    $SCHEDULE_NAMES_FROM_SCHEDULES\" \"$SCHEDULE_NAMES_FROM_BACKUPS\"\
+                    \ | grep -v '^$' | sort -u || true)\nCANDIDATE_COUNT=$(echo \"\
+                    $CANDIDATES\" | grep -c . 2>/dev/null || true); CANDIDATE_COUNT=${CANDIDATE_COUNT:-0}\n\
+                    \necho \"  Candidate schedules to evaluate:                  \
+                    \  $CANDIDATE_COUNT\"\necho \"  FailedValidation backups without\
+                    \ schedule-name label (always skipped): $UNLABELED_FV_COUNT\"\n\
+                    echo \"\"\n\n# Note: individual Backup names are intentionally\
+                    \ not logged\n# here (see \"No resource names in logs\" in the\
+                    \ README) - the\n# aggregate count above is the signal; inspect\
+                    \ the live\n# cluster for specifics if manual review is needed.\n\
+                    \nDELETED_SCHEDULES=0\nFAILED_SCHEDULES=0\nDELETED_BACKUPS=0\n\
+                    FAILED_BACKUPS=0\nSKIPPED_HC_EXISTS=0\nSKIPPED_BSL_EXISTS=0\n\
+                    SKIPPED_OWNED=0\nSKIPPED_UNPARSEABLE=0\nSKIPPED_STATIC=0\nSKIPPED_LOOKUP_ERROR=0\n\
+                    \nif [ \"$CANDIDATE_COUNT\" = \"0\" ]; then\n    echo \"  No candidate\
+                    \ schedules to evaluate.\"\nelse\n    IDX=0\n    while read -r\
+                    \ name; do\n        [ -z \"$name\" ] && continue\n        IDX=$((IDX\
+                    \ + 1))\n        echo \"[$IDX/$CANDIDATE_COUNT] Evaluating candidate\
+                    \ schedule\"\n\n        # Static, cluster-agnostic schedules (e.g.\n\
+                    \        # daily-full-backup, weekly-full-backup) are permanent\n\
+                    \        # infrastructure, never orphans. Ignore them quietly\
+                    \ -\n        # they do not need manual review.\n        if [[\
+                    \ \"$name\" == *-full-backup ]]; then\n            echo \"   \
+                    \ SKIP: static schedule (ignored)\"\n            SKIPPED_STATIC=$((SKIPPED_STATIC\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Parse CLUSTER_ID from the schedule name (convention:\n\
+                    \        # <cluster-id>-hourly, cluster ID is a 26-32 char\n \
+                    \       # lowercase alphanumeric string). Conservative: skip\n\
+                    \        # and report anything that doesn't confidently match\n\
+                    \        # rather than guessing at a cluster ID.\n        if [[\
+                    \ \"$name\" =~ ^([a-z0-9]{26,32})-hourly$ ]]; then\n         \
+                    \   CLUSTER_ID=\"${BASH_REMATCH[1]}\"\n        else\n        \
+                    \    echo \"    SKIP: could not parse cluster ID from schedule\
+                    \ name (manual review needed)\"\n            SKIPPED_UNPARSEABLE=$((SKIPPED_UNPARSEABLE\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Fail-closed: an oc lookup error must NOT be\
+                    \ read as\n        # \"HostedCluster absent\" (which would also\
+                    \ produce\n        # empty output). Capture output only on success;\
+                    \ on\n        # any error, skip this candidate for manual review\n\
+                    \        # rather than risking a false-positive deletion.\n  \
+                    \      if HC_OUTPUT=$(oc get hc -A -l \"api.openshift.com/id=${CLUSTER_ID}\"\
+                    \ \\\n            --no-headers --request-timeout=30s 2>/dev/null);\
+                    \ then\n            HC_COUNT=$(printf '%s' \"$HC_OUTPUT\" | grep\
+                    \ -c . || true)\n        else\n            echo \"    SKIP: could\
+                    \ not confirm HostedCluster absence (lookup error; manual review\
+                    \ needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n        if [ \"$HC_COUNT\" != \"0\" ]; then\n          \
+                    \  echo \"    SKIP: HostedCluster still exists for the parsed\
+                    \ cluster ID\"\n            SKIPPED_HC_EXISTS=$((SKIPPED_HC_EXISTS\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        # Distinguish a confirmed-absent BSL (NotFound)\
+                    \ from an\n        # actual lookup error (e.g. transient API issue).\
+                    \ Only\n        # a confirmed NotFound is treated as \"BSL absent\"\
+                    \ -\n        # any other error is conservatively skipped rather\n\
+                    \        # than assumed absent.\n        # Note: BSL_OUTPUT (the\
+                    \ raw oc error/output) is\n        # intentionally never logged\
+                    \ - only a generic,\n        # bounded status message is emitted\
+                    \ (see \"No\n        # resource names in logs\" in the README).\n\
+                    \        if BSL_OUTPUT=$(oc get backupstoragelocation \"$name\"\
+                    \ -n \"$NAMESPACE\" --request-timeout=30s -o name 2>&1); then\n\
+                    \            echo \"    SKIP: BackupStorageLocation still exists\"\
+                    \n            SKIPPED_BSL_EXISTS=$((SKIPPED_BSL_EXISTS + 1))\n\
+                    \            sleep 0.2\n            continue\n        elif ! echo\
+                    \ \"$BSL_OUTPUT\" | grep -qi \"NotFound\"; then\n            echo\
+                    \ \"    SKIP: could not confirm BackupStorageLocation absence\
+                    \ (lookup error; manual review needed)\"\n            SKIPPED_LOOKUP_ERROR=$((SKIPPED_LOOKUP_ERROR\
+                    \ + 1))\n            sleep 0.2\n            continue\n       \
+                    \ fi\n\n        SCHEDULE_EXISTS=$(echo \"$SCHEDULES_JSON\" | jq\
+                    \ --arg n \"$name\" '[.items[] | select(.metadata.name == $n)]\
+                    \ | length')\n        if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n\
+                    \            OWNER_COUNT=$(echo \"$SCHEDULES_JSON\" | jq --arg\
+                    \ n \"$name\" \\\n                '[.items[] | select(.metadata.name\
+                    \ == $n) | (.metadata.ownerReferences // [])] | flatten | length')\n\
+                    \            if [ \"$OWNER_COUNT\" != \"0\" ]; then\n        \
+                    \        echo \"    SKIP: Schedule has ownerReferences; flagging\
+                    \ for manual investigation\"\n                SKIPPED_OWNED=$((SKIPPED_OWNED\
+                    \ + 1))\n                sleep 0.2\n                continue\n\
+                    \            fi\n        fi\n\n        # Safe to clean up: HostedCluster\
+                    \ gone, BSL gone, and\n        # the Schedule (if present) has\
+                    \ no ownerReferences.\n        SAFE_TO_DELETE_BACKUPS=true\n \
+                    \       if [ \"$SCHEDULE_EXISTS\" != \"0\" ]; then\n         \
+                    \   if oc delete schedule \"$name\" -n \"$NAMESPACE\" --request-timeout=30s\
+                    \ --wait=false >/dev/null 2>&1; then\n                echo \"\
+                    \    OK:   deleted Schedule\"\n                DELETED_SCHEDULES=$((DELETED_SCHEDULES\
+                    \ + 1))\n            else\n                echo \"    FAIL: could\
+                    \ not delete Schedule\"\n                FAILED_SCHEDULES=$((FAILED_SCHEDULES\
+                    \ + 1))\n                SAFE_TO_DELETE_BACKUPS=false\n      \
+                    \      fi\n        else\n            echo \"    INFO: Schedule\
+                    \ object already absent; cleaning orphaned backups only\"\n  \
+                    \      fi\n\n        # Do not delete this schedule's FailedValidation\n\
+                    \        # backups if the Schedule itself failed to delete -\n\
+                    \        # avoid removing Backups while a (possibly transient)\n\
+                    \        # error left the Schedule in place; retry next run.\n\
+                    \        if [ \"$SAFE_TO_DELETE_BACKUPS\" = \"false\" ]; then\n\
+                    \            echo \"    SKIP: not deleting FailedValidation backups\
+                    \ because Schedule deletion failed\"\n            sleep 0.2\n\
+                    \            continue\n        fi\n\n        # Delete FailedValidation\
+                    \ backups for this schedule by\n        # EXACT name only - never\
+                    \ via a bare label selector,\n        # since that would not be\
+                    \ phase-aware and could match\n        # backups in other phases\
+                    \ (e.g. PartiallyFailed).\n        BACKUP_NAMES=$(echo \"$BACKUPS_JSON\"\
+                    \ | jq -r --arg n \"$name\" \\\n            '.items[] | select(.status.phase\
+                    \ == \"FailedValidation\") | select(.metadata.labels[\"velero.io/schedule-name\"\
+                    ] == $n) | .metadata.name')\n        BACKUP_NAMES=${BACKUP_NAMES:-}\n\
+                    \        if [ -n \"$BACKUP_NAMES\" ]; then\n            while\
+                    \ read -r bname; do\n                [ -z \"$bname\" ] && continue\n\
+                    \                if oc delete backup \"$bname\" -n \"$NAMESPACE\"\
+                    \ --request-timeout=30s --wait=false >/dev/null 2>&1; then\n \
+                    \                   echo \"    OK:   deleted Backup\"\n      \
+                    \              DELETED_BACKUPS=$((DELETED_BACKUPS + 1))\n    \
+                    \            else\n                    echo \"    FAIL: could\
+                    \ not delete Backup\"\n                    FAILED_BACKUPS=$((FAILED_BACKUPS\
+                    \ + 1))\n                fi\n                sleep 0.2\n     \
+                    \       done <<< \"$BACKUP_NAMES\"\n        fi\n\n        sleep\
+                    \ 0.2\n    done <<< \"$CANDIDATES\"\nfi\n\n# ============================================\n\
+                    # Summary\n# ============================================\necho\
+                    \ \"\"\necho \"==============================================\"\
+                    \necho \"  CLEANUP COMPLETE\"\necho \"==============================================\"\
+                    \necho \"\"\necho \"  Candidates evaluated:               $CANDIDATE_COUNT\"\
+                    \necho \"  Schedules deleted:                  $DELETED_SCHEDULES\
+                    \  (failed: $FAILED_SCHEDULES)\"\necho \"  FailedValidation backups\
+                    \ deleted:   $DELETED_BACKUPS  (failed: $FAILED_BACKUPS)\"\necho\
+                    \ \"  Skipped - HostedCluster exists:     $SKIPPED_HC_EXISTS\"\
+                    \necho \"  Skipped - BSL exists:               $SKIPPED_BSL_EXISTS\"\
+                    \necho \"  Skipped - lookup error (HC/BSL):    $SKIPPED_LOOKUP_ERROR\"\
+                    \necho \"  Skipped - Schedule has owners:      $SKIPPED_OWNED\"\
+                    \necho \"  Skipped - unparseable cluster ID:   $SKIPPED_UNPARSEABLE\"\
+                    \necho \"  Skipped - static schedule:          $SKIPPED_STATIC\"\
+                    \necho \"  Skipped - unlabeled FV backups:     $UNLABELED_FV_COUNT\"\
+                    \necho \"\"\necho \"  Total deleted:                      $((DELETED_SCHEDULES\
+                    \ + DELETED_BACKUPS))\"\necho \"  Total failures:            \
+                    \         $((FAILED_SCHEDULES + FAILED_BACKUPS))\"\necho \"\"\n\
+                    echo \"End time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')\"\n\n# Fail\
+                    \ the Job if any deletion failed, so partial cleanups\n# are recorded\
+                    \ as failed Jobs (visible via `oc get jobs`)\n# rather than silently\
+                    \ succeeding.\nif [ \"$FAILED_SCHEDULES\" != \"0\" ] || [ \"$FAILED_BACKUPS\"\
+                    \ != \"0\" ]; then\n    exit 1\nfi\n"
+                volumes:
+                - name: tmp
+                  emptyDir: {}
+                serviceAccountName: oadp-orphaned-schedule-cleanup
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-oadp-vsc-cleanup
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Adds a new `hypershift-oadp-orphaned-schedule-cleanup` CronJob deployed to HyperShift **management clusters** (in the `openshift-adp` namespace) that cleans up orphaned Velero `Schedule` CRs and their associated `FailedValidation` `Backup` CRs.

**Background / problem:** During hourly-backup enablement, some short-lived clusters had 1-hourly Velero `Schedule`s created that were never properly assigned to a parent `AppliedManifestWork`. The associated `BackupStorageLocation` (BSL) likely never existed, and the cluster has since been deleted. As a result, backups fail hourly (`FailedValidation` / `BSLNotFound`) and `Backup` CRs accumulate with no pruning mechanism, eventually firing the `OADPBackupCRAccumulation` alert.

**What it does:** A daily CronJob enumerates `Schedule`s and `FailedValidation` `Backup`s, then deletes both the `Schedule` and its `FailedValidation` backups **only if all** of the following hold:
- the associated `HostedCluster` no longer exists (`oc get hc -A -l api.openshift.com/id=${CLUSTER_ID}`), **and**
- no `BackupStorageLocation` of the same name exists (`oc get backupstoragelocation ${SCHEDULE_NAME} -n openshift-adp`), **and**
- the `Schedule` has no `ownerReferences`.

All other cases are skipped and reported rather than deleted.

### Which Jira/Github issue(s) this PR fixes?

[ROSAENG-65780](https://redhat.atlassian.net/browse/ROSAENG-65780)

_Fixes #_

### Special notes for your reviewer:

- **Exact-name deletes only:** backup deletions always target exact `Backup` CR names, never a bare `-l velero.io/schedule-name=<name>` label selector, because that selector is phase-unaware and could match backups in other phases that must not be deleted.
- **Static schedules ignored:** `*-full-backup` schedules (e.g. `daily-full-backup`, `weekly-full-backup`) are permanent infrastructure and are explicitly, silently skipped (separate counter, not flagged for manual review).
- **Conservative cluster-ID parsing:** the cluster ID is parsed from the `<cluster-id>-hourly` schedule-name convention (26-32 char lowercase alphanumeric ID); any name that doesn't confidently match is skipped and reported for manual review rather than guessed at.
- **Active by default:** the CronJob runs daily at 03:00 UTC and is **not** suspended (differs from the suspended VSC-cleanup reference component).
- The `hack/00-osd-managed-cluster-config-*.yaml.tmpl` changes are **auto-generated** via `make generate-hive-templates` and were not hand-edited.
- Reference SOP: https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/oadp/OADPBackupCRAccumulation.md

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a daily automated cleanup job for orphaned OADP schedules and associated failed-validation backups.
  - Added safeguards to skip ambiguous, malformed, owned, or otherwise unsafe resources.
  - Configured deployment to HyperShift management clusters, excluding FedRAMP-enabled clusters.
  - Added restricted permissions and security settings for safer execution.

- **Documentation**
  - Added guidance for deployment, manual runs, pausing, monitoring, troubleshooting, and reviewing skipped resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->