### PR TITLE
Remove leftover osd-cluster-ready entries from the managed resources allowlist

### DIFF
--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -170,8 +170,6 @@ Resources:
   - namespace: openshift-monitoring
     name: configure-alertmanager-operator
   - namespace: openshift-monitoring
-    name: osd-cluster-ready
-  - namespace: openshift-monitoring
     name: osd-rebalance-infra-nodes
   - namespace: openshift-monitoring
     name: sre-dns-latency-exporter
@@ -259,7 +257,6 @@ Resources:
   - name: logger-clusterrolebinding
   - name: openshift-backplane-managed-scripts-reader
   - name: osd-cluster-admin
-  - name: osd-cluster-ready
   - name: osd-delete-backplane-script-resources
   - name: osd-delete-ownerrefs-serviceaccounts
   - name: osd-patch-subscription-source
@@ -289,7 +286,6 @@ Resources:
   - name: logger-clusterrole
   - name: openshift-backplane-managed-scripts-reader
   - name: openshift-splunk-forwarder-operator
-  - name: osd-cluster-ready
   - name: osd-custom-domains-dedicated-admin-cluster
   - name: osd-delete-backplane-script-resources
   - name: osd-delete-backplane-serviceaccounts
@@ -330,8 +326,6 @@ Resources:
     name: muo-pullsecret-reader
   - namespace: openshift-config
     name: oao-openshiftconfig-reader
-  - namespace: openshift-config
-    name: osd-cluster-ready
   - namespace: openshift-custom-domains-operator
     name: osd-rebalance-infra-nodes-openshift-pod-rebalance
   - namespace: openshift-customer-monitoring
@@ -361,8 +355,6 @@ Resources:
   - namespace: openshift-logging
     name: openshift-logging:serviceaccounts:dedicated-admin
   - namespace: openshift-machine-api
-    name: osd-cluster-ready
-  - namespace: openshift-machine-api
     name: sre-ebs-iops-reporter-read-machine-info
   - namespace: openshift-machine-api
     name: sre-stuck-ebs-vols-read-machine-info
@@ -378,8 +370,6 @@ Resources:
     name: muo-monitoring-reader
   - namespace: openshift-monitoring
     name: oao-monitoring-manager
-  - namespace: openshift-monitoring
-    name: osd-cluster-ready
   - namespace: openshift-monitoring
     name: osd-rebalance-infra-nodes-openshift-monitoring
   - namespace: openshift-monitoring
@@ -467,8 +457,6 @@ Resources:
     name: muo-pullsecret-reader
   - namespace: openshift-config
     name: oao-openshiftconfig-reader
-  - namespace: openshift-config
-    name: osd-cluster-ready
   - namespace: openshift-customer-monitoring
     name: dedicated-admins-openshift-customer-monitoring
   - namespace: openshift-customer-monitoring
@@ -488,8 +476,6 @@ Resources:
   - namespace: openshift-logging
     name: dedicated-admins-openshift-logging
   - namespace: openshift-machine-api
-    name: osd-cluster-ready
-  - namespace: openshift-machine-api
     name: osd-disable-cpms
   - namespace: openshift-marketplace
     name: dedicated-admins-openshift-marketplace
@@ -499,8 +485,6 @@ Resources:
     name: muo-monitoring-reader
   - namespace: openshift-monitoring
     name: oao-monitoring-manager
-  - namespace: openshift-monitoring
-    name: osd-cluster-ready
   - namespace: openshift-monitoring
     name: osd-rebalance-infra-nodes-openshift-monitoring
   - namespace: openshift-must-gather-operator
@@ -552,9 +536,6 @@ Resources:
     name: bz1980755
   - namespace: openshift-sre-pruning
     name: deployments-pruner
-  Job:
-  - namespace: openshift-monitoring
-    name: osd-cluster-ready
   CredentialsRequest:
   - namespace: openshift-cloud-ingress-operator
     name: cloud-ingress-operator-credentials-aws


### PR DESCRIPTION
## Summary
- Drop leftover `osd-cluster-ready` objects from `resources/managed/all-osd-resources.yaml`.
- Follow-up to https://github.com/openshift/managed-cluster-config/pull/2771, which undeployed the Job.

## Test plan
- [ ] Confirm `osd-cluster-ready` no longer appears in `all-osd-resources.yaml`.
- [ ] Unrelated allowlist entries are unchanged.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete `osd-cluster-ready` resource from managed resource inventories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->