### PR TITLE
fix(ROSAENG-65780): bump memory limit for oadp-orphaned-schedule-cleanup jobs to 1Gi

### DIFF
--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/10-cronjob.yaml
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/10-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
                 memory: "100Mi"
                 cpu: "100m"
               limits:
-                memory: "512Mi"
+                memory: "1Gi"
                 cpu: "500m"
             volumeMounts:
             - name: tmp

--- a/deploy/hypershift-oadp-orphaned-schedule-cleanup/README.md
+++ b/deploy/hypershift-oadp-orphaned-schedule-cleanup/README.md
@@ -152,7 +152,7 @@ oc create job --from=cronjob/oadp-orphaned-schedule-cleanup manual-cleanup-$(dat
 - **No resource names or cluster IDs in logs**: per-item log lines emit only generic status classifications (e.g. `SKIP: BackupStorageLocation still exists`) and the final summary reports aggregate counts only. Schedule/Backup names, parsed cluster IDs, and raw `oc` lookup error output are never printed, so retained Job logs cannot leak internal identifiers or API error details. To investigate a specific skip/failure, query the live cluster directly (e.g. `oc get schedules,backups -n openshift-adp -o wide`).
 - **Idempotent**: safe to re-run; already-cleaned resources simply won't appear as candidates.
 - **Concurrency protection**: `concurrencyPolicy: Forbid` prevents overlapping runs.
-- **Resource limits**: the container defines both `requests` and `limits` (`memory: 512Mi`, `cpu: 500m`) to bound memory usage given the potentially large in-memory Schedule/Backup JSON inventories.
+- **Resource limits**: the container defines both `requests` (`memory: 100Mi`, `cpu: 100m`) and `limits` (`memory: 1Gi`, `cpu: 500m`) to bound memory usage given the potentially large in-memory Schedule/Backup JSON inventories.
 - **Read-only root filesystem**: the container runs with `readOnlyRootFilesystem: true`; a writable `emptyDir` is mounted at `/tmp` (with `HOME`/`TMPDIR` pointed there) for any temporary files `oc`/`jq` need to write.
 - **History preserved**: previous Job logs can be reviewed via `oc get jobs` / `oc logs`.
 - **Fails visibly on partial cleanup**: if any Schedule or Backup deletion fails, the job exits non-zero and the Job is marked failed (visible via `oc get jobs`) rather than silently reporting success.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31089,7 +31089,7 @@ objects:
                       memory: 100Mi
                       cpu: 100m
                     limits:
-                      memory: 512Mi
+                      memory: 1Gi
                       cpu: 500m
                   volumeMounts:
                   - name: tmp

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31089,7 +31089,7 @@ objects:
                       memory: 100Mi
                       cpu: 100m
                     limits:
-                      memory: 512Mi
+                      memory: 1Gi
                       cpu: 500m
                   volumeMounts:
                   - name: tmp

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31089,7 +31089,7 @@ objects:
                       memory: 100Mi
                       cpu: 100m
                     limits:
-                      memory: 512Mi
+                      memory: 1Gi
                       cpu: 500m
                   volumeMounts:
                   - name: tmp


### PR DESCRIPTION

### What type of PR is this?
_fix_

### What this PR does / why we need it?

Bumps the memory limit for the `oadp-orphaned-schedule-cleanup` jobs as they are failing with `OOMKilled` on MCs with the highest density of backups.

Highest observed usage was `960Mi`.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [ROSAENG-65780](https://redhat.atlassian.net/browse/ROSAENG-65780)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased memory available to the scheduled cleanup task, improving reliability during execution.
  * Updated the documented resource limits to reflect the current configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->