### PR TITLE
[ROSAENG-64788] removing noise from backup logs

### DIFF
--- a/deploy/velero-configuration/110-velero.Schedules.yaml
+++ b/deploy/velero-configuration/110-velero.Schedules.yaml
@@ -25,6 +25,21 @@ spec:
     - serviceplans.servicecatalog.k8s.io
     - events.events.k8s.io
     - events
+    - backups.velero.io
+    - backupstoragelocations.velero.io
+    - schedules.velero.io
+    - deletebackuprequests.velero.io
+    - downloadrequests.velero.io
+    - restores.velero.io
+    - serverstatusrequests.velero.io
+    - podvolumebackups.velero.io
+    - podvolumerestores.velero.io
+    - resticrepositories.velero.io
+    - backuprepositories.velero.io
+    - configurationpolicies.policy.open-cluster-management.io
+    - policies.policy.open-cluster-management.io
+    - profiles.tuned.openshift.io
+    - tuneds.tuned.openshift.io
     snapshotVolumes: false
     ttl: 168h0m0s
 ---
@@ -55,6 +70,17 @@ spec:
     - serviceplans.servicecatalog.k8s.io
     - events.events.k8s.io
     - events
+    - backups.velero.io
+    - backupstoragelocations.velero.io
+    - schedules.velero.io
+    - deletebackuprequests.velero.io
+    - downloadrequests.velero.io
+    - restores.velero.io
+    - serverstatusrequests.velero.io
+    - podvolumebackups.velero.io
+    - podvolumerestores.velero.io
+    - resticrepositories.velero.io
+    - backuprepositories.velero.io
     snapshotVolumes: false
     ttl: 24h0m0s
 ---
@@ -85,5 +111,16 @@ spec:
     - serviceplans.servicecatalog.k8s.io
     - events.events.k8s.io
     - events
+    - backups.velero.io
+    - backupstoragelocations.velero.io
+    - schedules.velero.io
+    - deletebackuprequests.velero.io
+    - downloadrequests.velero.io
+    - restores.velero.io
+    - serverstatusrequests.velero.io
+    - podvolumebackups.velero.io
+    - podvolumerestores.velero.io
+    - resticrepositories.velero.io
+    - backuprepositories.velero.io
     snapshotVolumes: false
     ttl: 720h0m0s

--- a/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
+++ b/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
@@ -25,5 +25,20 @@ spec:
     - serviceplans.servicecatalog.k8s.io
     - events.events.k8s.io
     - events
+    - backups.velero.io
+    - backupstoragelocations.velero.io
+    - schedules.velero.io
+    - deletebackuprequests.velero.io
+    - downloadrequests.velero.io
+    - restores.velero.io
+    - serverstatusrequests.velero.io
+    - podvolumebackups.velero.io
+    - podvolumerestores.velero.io
+    - resticrepositories.velero.io
+    - backuprepositories.velero.io
+    - configurationpolicies.policy.open-cluster-management.io
+    - policies.policy.open-cluster-management.io
+    - profiles.tuned.openshift.io
+    - tuneds.tuned.openshift.io
     snapshotVolumes: false
     ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -50077,6 +50077,21 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -50106,6 +50121,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -50135,6 +50161,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 720h0m0s
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -50225,5 +50262,20 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -50077,6 +50077,21 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -50106,6 +50121,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -50135,6 +50161,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 720h0m0s
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -50225,5 +50262,20 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -50077,6 +50077,21 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -50106,6 +50121,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -50135,6 +50161,17 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
           snapshotVolumes: false
           ttl: 720h0m0s
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -50225,5 +50262,20 @@ objects:
           - serviceplans.servicecatalog.k8s.io
           - events.events.k8s.io
           - events
+          - backups.velero.io
+          - backupstoragelocations.velero.io
+          - schedules.velero.io
+          - deletebackuprequests.velero.io
+          - downloadrequests.velero.io
+          - restores.velero.io
+          - serverstatusrequests.velero.io
+          - podvolumebackups.velero.io
+          - podvolumerestores.velero.io
+          - resticrepositories.velero.io
+          - backuprepositories.velero.io
+          - configurationpolicies.policy.open-cluster-management.io
+          - policies.policy.open-cluster-management.io
+          - profiles.tuned.openshift.io
+          - tuneds.tuned.openshift.io
           snapshotVolumes: false
           ttl: 0h25m0s


### PR DESCRIPTION
### What type of PR is this?
[Ticket](https://redhat.atlassian.net/browse/ROSAENG-64788)
Aim here is to remove the noise within MC backups around resources that can not be backed up or are managed via ACM, thus are not recreated (or shouldn't be) via a restore

More on the issue can be found [here in the ticket](https://redhat.atlassian.net/browse/ROSAENG-64788?focusedCommentId=18137913)

####Summary is as follows:
On management cluster `hs-mc-kbj34s6bg`, the hive-managed `daily-full-backup` schedule completes as `PartiallyFailed` with ~16k item errors. Investigation shows the resulting object in the backup bucket contains **only `metadata/version`** — no resources at all. Every error is the *same* error, emitted by the `hypershift-oadp-plugin` BackupItemAction (BIA): it runs against resources that have **no associated HostedControlPlane**, performs an all-namespace HCP lookup, fails with `no HostedControlPlane found`, and returns an rpc error. Because Velero aborts an item's archival when its BIA errors, essentially every item is excluded from the tarball.

####Fix as per suggestion from @andrebeltrami 
[See suggestion here](https://redhat.atlassian.net/browse/ROSAENG-64788?focusedCommentId=18139157)

The storage layer is healthy and has been ruled out.

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated daily, hourly, weekly, and environment-specific backup schedules to exclude Velero’s own management resources.
  * Prevented backup metadata, restore records, repository resources, volume backup and restore objects, and related resources from being redundantly backed up.
  * Added exclusions for Open Cluster Management policy resources and selected OpenShift Tuned resources where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->