### PR TITLE
ROSAENG-60481 add extra permissions for OCP 5

### DIFF
--- a/resources/sts/5.0/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
+++ b/resources/sts/5.0/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
@@ -19,7 +19,11 @@
         "ec2:DescribeVolumesModifications",
         "ec2:DetachVolume",
         "ec2:EnableFastSnapshotRestores",
-        "ec2:ModifyVolume"
+        "ec2:ModifyVolume",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeVolumeStatus",
+        "ec2:CopyVolumes",
+        "ec2:LockSnapshot"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
### What type of PR is this?
Added extra STS permissions which were added into OCP 5

### What this PR does / why we need it?
OCP 5 added 4 more extra permissions for aws-ebs-csi-driver-operator CloudCredential request.
This PR updated the STS permission set in managed-cluster-config 

### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-60481](https://redhat.atlassian.net/browse/ROSAENG-60481)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated EBS cloud credentials permissions to support additional volume and snapshot operations.
  * Added access for describing instance types and volume status, copying volumes, and locking snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->