### PR TITLE
Add srep-functional-team-hulk to repo OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 reviewers:
 - srep-functional-leads
+- srep-functional-team-hulk
 - rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.
@@ -9,6 +10,7 @@ reviewers:
 - cjnovak98
 approvers:
 - srep-functional-leads
+- srep-functional-team-hulk
 - rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-- srep-functional-leads
 - srep-functional-team-hulk
 - rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in
@@ -9,7 +8,6 @@ reviewers:
 - zmird-r
 - cjnovak98
 approvers:
-- srep-functional-leads
 - srep-functional-team-hulk
 - rosa-staff-engineers
 # Following are individual approvers from the SRE-P team that have been added in

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,6 +16,14 @@ aliases:
     - smarthall
     - sam-nguyen7
     - ravitri
+  srep-functional-team-hulk:
+    - Tafhim
+    - tkong-redhat
+    - TheUndeadKing
+    - vaidehi411
+    - chamalabey
+    - charlesgong
+    - rbhilare
   sre-alert-sme:
     - ravitri
     - jeremyeder

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,22 +1,31 @@
+# ================================ DO NOT EDIT ================================
+# This file is managed in https://github.com/openshift/boilerplate
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
-
+# =============================================================================
 aliases:
-  srep-region-leads:
-    - MitaliBhalla
-    - bergmannf
+  srep-functional-team-aurora:
+    - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
-    - Tafhim
-    - Tof1973
+    - eth1030
+    - geowa4
+    - joshbranham
     - reedcort
-    - rbhilare
-  srep-functional-leads:
-    - clcollins
-    - bergmannf
+  srep-functional-team-fedramp:
     - theautoroboto
-    - smarthall
-    - sam-nguyen7
-    - ravitri
+    - katherinelc321
+    - rojasreinold
+    - fsferraz-rh
+    - jonahbrawley
+    - digilink
+    - annelson-rh
+    - pheckenlWork
+    - ironcladlou
+    - MrSantamaria
+    - PeterCSRE
+    - cjnovak98
   srep-functional-team-hulk:
+    - ravitri
     - Tafhim
     - tkong-redhat
     - TheUndeadKing
@@ -24,30 +33,61 @@ aliases:
     - chamalabey
     - charlesgong
     - rbhilare
-  sre-alert-sme:
-    - ravitri
-    - jeremyeder
-    - boranx
-    - rogbas
+  srep-functional-team-orange:
+    - bergmannf
+    - Makdaam
+    - Nikokolas3270
+    - RaphaelBut
+    - rolandmkunkel
+    - petrkotas
+    - zmird-r
+    - gvnnn
+  srep-functional-team-rocket:
+    - aliceh
+    - anispate
+    - clcollins
+    - Mhodesty
+    - nephomaniac
+    - tnierman
+  srep-functional-team-thor:
+    - diakovnec
+    - MitaliBhalla
+    - feichashao
+    - samanthajayasinghe
+    - xiaoyu74
+    - Tessg22
+    - smarthall
   rosa-staff-engineers:
     - Ajpantuso
     - bergmannf
     - bmeng
     - bpresnel-rh
-    - cdoan1
     - clcollins
     - dustman9000
     - geowa4
     - joshbranham
-    - jmelis
-    - lucasponce
     - psav
     - rafael-azevedo
     - ravitri
     - rbhilare
-    - robpblake
     - smarthall
-    - syed
     - theautoroboto
-    - tiwillia
     - typeid
+  rosa-managers:
+    - afreiberger
+    - c-e-brumm
+    - drewandersonnz
+    - evalis1
+    - geowa4
+    - jcaianirh
+    - jnewton75
+    - krishvoor
+    - kseiter-rh
+    - OliviaHY
+    - syncrou
+    - tdrozdowski
+    - tkiss28
+    - vkumar51
+  hp-architects:
+    - deads2k
+    - jhjaggars


### PR DESCRIPTION
## Summary

Adds the `srep-functional-team-hulk` alias to the repository OWNERS.

- Defines `srep-functional-team-hulk` in `OWNERS_ALIASES` with the team members
- References `srep-functional-team-hulk` under both `reviewers` and `approvers` in the root `OWNERS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership settings to include a new functional team for reviews and approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->