### PR TITLE
Add sync-owners-aliases Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ $(error CHECK_SSS_CONFLICTS is not set; check project.mk file)
 endif
 
 POLICYGEN_VERSION=v1.12.4
+BOILERPLATE_REPO_RAW=https://raw.githubusercontent.com/openshift/boilerplate/master
 
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
@@ -61,7 +62,15 @@ OC := $(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) quay.io/openshift/origin-cl
 endif
 
 .PHONY: default
-default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates
+default: check-sss-conflicts enforce-backplane-rules generate-oauth-templates generate-rosa-brand-logo generate-hive-templates sync-owners-aliases
+
+.PHONY: sync-owners-aliases
+sync-owners-aliases:
+	tmpfile=$$(mktemp OWNERS_ALIASES.XXXXXX); \
+	trap 'rm -f "$$tmpfile"' EXIT; \
+	curl -fsSL --connect-timeout 10 --max-time 30 $(BOILERPLATE_REPO_RAW)/OWNERS_ALIASES -o "$$tmpfile" && \
+	chmod 0644 "$$tmpfile" && \
+	mv "$$tmpfile" OWNERS_ALIASES
 
 .PHONY: generate-oauth-templates
 generate-oauth-templates:


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?

Add a target to automatically fetch OWNERS_ALIASES from the openshift/boilerplate repo, keeping it in lockstep with the upstream source of truth. The target runs as part of the default target so that every time selector sync sets are generated, OWNERS_ALIASES is also refreshed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automatic synchronization of ownership aliases from the boilerplate repository.
  * Updated the default build workflow to include ownership alias synchronization.
  * Improved synchronization reliability by safely replacing aliases only after a successful download.
  * Prevented incomplete or failed downloads from overwriting the current ownership aliases.
  * Ensured temporary synchronization files are cleaned up after completion or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->