### PR TITLE
ROSAENG-3733: Add SC kube-state-metrics for cert-manager Challenges

### DIFF
--- a/deploy/hypershift-sc-kube-state-metrics/010-namespace.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/010-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hypershift-observability
+  labels:
+    name: hypershift-observability
+    hypershift.openshift.io/monitoring: "true"

--- a/deploy/hypershift-sc-kube-state-metrics/020-deployment.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/020-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: v2.17.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: v2.17.0
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        args:
+        - --host=0.0.0.0
+        - --port=8080
+        - --telemetry-host=0.0.0.0
+        - --telemetry-port=8081
+        - --custom-resource-state-only=true
+        - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: kube-state-metrics-config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/deploy/hypershift-sc-kube-state-metrics/025-configmap.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/025-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-state-metrics-config
+  namespace: hypershift-observability
+data:
+  custom-resource-state.yaml: |
+    spec:
+      resources:
+        # ---- cert-manager Challenge CRs (ROSAENG-3733) ----
+        # Slim vs management-cluster KSM: SC does not need CAPI/NodePool/Velero watches.
+        - groupVersionKind:
+            group: acme.cert-manager.io
+            version: v1
+            kind: Challenge
+          metricNamePrefix: certmanager_challenge_cr
+          labelsFromPath:
+            challenge_name:
+              - metadata
+              - name
+            exported_namespace:
+              - metadata
+              - namespace
+          metrics:
+            - name: "created"
+              help: "Creation timestamp of cert-manager Challenge CR."
+              each:
+                type: Gauge
+                gauge:
+                  path: [metadata, creationTimestamp]
+            - name: "info"
+              help: "cert-manager Challenge CR with state label."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    state: [status, state]

--- a/deploy/hypershift-sc-kube-state-metrics/030-serviceaccount.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/030-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics

--- a/deploy/hypershift-sc-kube-state-metrics/040-clusterrole.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/040-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hypershift-sc-kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/hypershift-sc-kube-state-metrics/050-clusterrolebinding.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/050-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hypershift-sc-kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hypershift-sc-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: hypershift-observability

--- a/deploy/hypershift-sc-kube-state-metrics/060-service.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/060-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/deploy/hypershift-sc-kube-state-metrics/070-servicemonitor.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/070-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+  - port: http-metrics
+    interval: 30s
+    path: /metrics

--- a/deploy/hypershift-sc-kube-state-metrics/README.md
+++ b/deploy/hypershift-sc-kube-state-metrics/README.md
@@ -1,0 +1,7 @@
+# Hypershift SC kube-state-metrics (cert-manager Challenges)
+
+Same custom-resource-state KSM pattern as `deploy/hypershift-kube-state-metrics`, but **SelectorSyncSet to service-cluster only**.
+
+ROSAENG-3733 RHOBS alerts `CertManagerChallengeQueueSaturation` / `QueueFull` need `certmanager_challenge_cr_info` on **SC** (ingress ACME). The existing SSS is `management-cluster` only (#2802).
+
+This stack only watches `acme.cert-manager.io` Challenges so we do not ship CAPI/NodePool/Velero scrapes onto SCs.

--- a/deploy/hypershift-sc-kube-state-metrics/config.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/config.yaml
@@ -1,0 +1,10 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31926,6 +31926,206 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sc-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    # ---- cert-manager\
+          \ Challenge CRs (ROSAENG-3733) ----\n    # Slim vs management-cluster KSM:\
+          \ SC does not need CAPI/NodePool/Velero watches.\n    - groupVersionKind:\n\
+          \        group: acme.cert-manager.io\n        version: v1\n        kind:\
+          \ Challenge\n      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]\n"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-sc-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31926,6 +31926,206 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sc-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    # ---- cert-manager\
+          \ Challenge CRs (ROSAENG-3733) ----\n    # Slim vs management-cluster KSM:\
+          \ SC does not need CAPI/NodePool/Velero watches.\n    - groupVersionKind:\n\
+          \        group: acme.cert-manager.io\n        version: v1\n        kind:\
+          \ Challenge\n      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]\n"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-sc-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31926,6 +31926,206 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sc-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    # ---- cert-manager\
+          \ Challenge CRs (ROSAENG-3733) ----\n    # Slim vs management-cluster KSM:\
+          \ SC does not need CAPI/NodePool/Velero watches.\n    - groupVersionKind:\n\
+          \        group: acme.cert-manager.io\n        version: v1\n        kind:\
+          \ Challenge\n      metricNamePrefix: certmanager_challenge_cr\n      labelsFromPath:\n\
+          \        challenge_name:\n          - metadata\n          - name\n     \
+          \   exported_namespace:\n          - metadata\n          - namespace\n \
+          \     metrics:\n        - name: \"created\"\n          help: \"Creation\
+          \ timestamp of cert-manager Challenge CR.\"\n          each:\n         \
+          \   type: Gauge\n            gauge:\n              path: [metadata, creationTimestamp]\n\
+          \        - name: \"info\"\n          help: \"cert-manager Challenge CR with\
+          \ state label.\"\n          each:\n            type: Info\n            info:\n\
+          \              labelsFromPath:\n                state: [status, state]\n"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+      - apiGroups:
+        - acme.cert-manager.io
+        resources:
+        - challenges
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-sc-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-sc-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
## Summary

- New SelectorSyncSet `hypershift-sc-kube-state-metrics` targeting **service-cluster** (not FedRAMP).
- Same custom-resource-state KSM as MC, but **only** `acme.cert-manager.io` Challenges (`certmanager_challenge_cr_*`).
- Needed so RHOBS `CertManagerChallengeQueueSaturation` / `QueueFull` can fire on SC (ingress ACME). [managed-cluster-config#2802](https://github.com/openshift/managed-cluster-config/pull/2802) is MC-only.

Does not add CAPI/NodePool/Velero scrapes on SC.

Hive templates regenerated (`hack/00-osd-managed-cluster-config-*.yaml.tmpl`).

Related: [ROSAENG-3733](https://redhat.atlassian.net/browse/ROSAENG-3733)

### What type of PR is this?
feature

### What this PR does / why we need it?
Expose Challenge CR metrics on Service Clusters for RHOBS queue-saturation alerts (ITN-2025-00317 was SC).

### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-3733](https://redhat.atlassian.net/browse/ROSAENG-3733)

## Test plan

- [ ] SSS selects `service-cluster` only
- [ ] After pin: `certmanager_challenge_cr_info` on a stage SC
- [ ] MC stack (`hypershift-kube-state-metrics`) unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-cluster monitoring for cert-manager Challenge resources.
  * Exposes Challenge creation timestamps and status metrics for observability and alerting.
  * Automatically scrapes and publishes metrics through Prometheus.
  * Deploys the monitoring components to eligible service clusters while excluding FedRAMP clusters.

* **Documentation**
  * Added deployment documentation describing the monitoring stack and available metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->