### PR TITLE
Reduce the upgrade policy polling interval

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -9,7 +9,7 @@ data:
     configManager:
       source: OCM
       ocmBaseUrl: ${OCM_BASE_URL}
-      watchInterval: 60
+      watchInterval: 10
     maintenance:
       controlPlaneTime: 130
       ignoredAlerts:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32313,7 +32313,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 10\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32313,7 +32313,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 10\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32313,7 +32313,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 10\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \


### PR DESCRIPTION


### What type of PR is this?
Reduce the upgrade policy polling interval to 10 mins as requested by critical customer

### What this PR does / why we need it?
Critical customer is complain that 1 hour interval is too slow which has huge impact on their upgrade plan. Had checked with OCM team and agreed to reduce the interval to 10 mins.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the responsiveness of managed upgrade configuration updates by reducing the configuration watch interval from 60 to 10 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->