### PR TITLE
ROSAENG-65928 Add STS ack for upgrade to 5.0 for HCP clusters

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-cluster-acks-hcp-5.0.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-acks-hcp-5.0.Policy.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: osd-cluster-acks-hcp-5.0
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: osd-cluster-acks-hcp-5.0
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates-raw: |
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: operator.openshift.io/v1
+                        kind: CloudCredential
+                        metadata:
+                          name: cluster
+                          annotations:
+                            cloudcredential.openshift.io/upgradeable-to: "v5.0"
+                remediationAction: enforce
+                severity: high
+    remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-osd-cluster-acks-hcp-5.0
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+            - key: openshiftVersion-major-minor
+              operator: In
+              values:
+                - "4.22"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-osd-cluster-acks-hcp-5.0
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-osd-cluster-acks-hcp-5.0
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: osd-cluster-acks-hcp-5.0

--- a/deploy/osd-cluster-acks/hcp/5.0/00-osd-sts-ack.ConfigurationPolicy.yaml
+++ b/deploy/osd-cluster-acks/hcp/5.0/00-osd-sts-ack.ConfigurationPolicy.yaml
@@ -1,0 +1,36 @@
+# OSD STS upgrade acknowledgement for HCP clusters (4.22 -> 5.0)
+#
+# HCP hosted clusters are managed through ACM policies rather than Hive
+# SelectorSyncSets. This policy patches the pre-existing CloudCredential/cluster
+# resource to add the cloudcredential.openshift.io/upgradeable-to annotation so
+# the cluster-version-operator upgrade gate is acknowledged and the upgrade to
+# v5.0 is unblocked.
+#
+# complianceType/metadataComplianceType: musthave enforces (merges) only the
+# specified annotation onto the existing object; it does not create or fully
+# own the CloudCredential, and no other fields are altered.
+#
+# Mirrors the SelectorSyncSet-based ack used for classic STS clusters in
+# deploy/osd-cluster-acks/sts/5.0.
+#
+# Tracking: ROSAENG-65928
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: osd-cluster-acks-hcp-5.0
+spec:
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 45s
+  object-templates-raw: |
+    - complianceType: musthave
+      metadataComplianceType: musthave
+      objectDefinition:
+        apiVersion: operator.openshift.io/v1
+        kind: CloudCredential
+        metadata:
+          name: cluster
+          annotations:
+            cloudcredential.openshift.io/upgradeable-to: "v5.0"
+  remediationAction: enforce
+  severity: high

--- a/deploy/osd-cluster-acks/hcp/5.0/config.yaml
+++ b/deploy/osd-cluster-acks/hcp/5.0/config.yaml
@@ -1,0 +1,13 @@
+deploymentMode: Policy
+clusterSelectors:
+  matchExpressions:
+    - key: hypershift.open-cluster-management.io/hosted-cluster
+      operator: In
+      values:
+        - "true"
+    - key: openshiftVersion-major-minor
+      operator: In
+      values:
+        - "4.22"
+policy:
+  complianceType: "musthave"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7640,6 +7640,64 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-cluster-acks-hcp-5.0
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: CloudCredential\n    metadata:\n      name: cluster\n \
+                \     annotations:\n        cloudcredential.openshift.io/upgradeable-to:\
+                \ \"v5.0\"\n"
+              remediationAction: enforce
+              severity: high
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+          - key: openshiftVersion-major-minor
+            operator: In
+            values:
+            - '4.22'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-cluster-acks-hcp-5.0
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-cluster-acks-hcp-5.0
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7640,6 +7640,64 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-cluster-acks-hcp-5.0
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: CloudCredential\n    metadata:\n      name: cluster\n \
+                \     annotations:\n        cloudcredential.openshift.io/upgradeable-to:\
+                \ \"v5.0\"\n"
+              remediationAction: enforce
+              severity: high
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+          - key: openshiftVersion-major-minor
+            operator: In
+            values:
+            - '4.22'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-cluster-acks-hcp-5.0
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-cluster-acks-hcp-5.0
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7640,6 +7640,64 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-cluster-acks-hcp-5.0
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: CloudCredential\n    metadata:\n      name: cluster\n \
+                \     annotations:\n        cloudcredential.openshift.io/upgradeable-to:\
+                \ \"v5.0\"\n"
+              remediationAction: enforce
+              severity: high
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+          - key: openshiftVersion-major-minor
+            operator: In
+            values:
+            - '4.22'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-cluster-acks-hcp-5.0
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-cluster-acks-hcp-5.0
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-cluster-acks-hcp-5.0
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -30,6 +30,7 @@ directories = [
         'customer-registry-cas',
         'hcp-ze-ecr-creds',
         'hypershift-ovn-logging',
+        'osd-cluster-acks/hcp/5.0',
         'osd-cluster-admin',
         'ocpbugs-88685-metrics-proxy-memory-limit',
         'osd-customer-monitoring',


### PR DESCRIPTION
### What type of PR is this?
Add STS ack for upgrade to 5.0 for HCP clusters

### What this PR does / why we need it?
Since 4.22, cloud credential operator is enabled on HCP clusters.
STS ack is required for HCP on cloud credential operator upgrade for 5.0.
Otherwise the upgrade will be blocked.


### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-65928](https://redhat.atlassian.net/browse/ROSAENG-65928) 
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated upgrade acknowledgments for hosted OSD clusters running OpenShift 4.22 and upgrading to version 5.0.
  * Policies target eligible hosted clusters and enforce the required CloudCredential upgrade annotation.
  * Added policy deployment configuration and generation support for this upgrade path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->