### PR TITLE
Add g6e instance types to rosa-cpus-instance-types-config

### DIFF
--- a/deploy/rosa-cpus-instance-types-config/README.md
+++ b/deploy/rosa-cpus-instance-types-config/README.md
@@ -10,6 +10,14 @@ The hypershift-operator (HO v0.1.75+, [OCPBUGS-50003](https://issues.redhat.com/
 |---------------|-------|
 | `i3.metal` | 72 |
 | `g6.xlarge` | 4 |
+| `g6e.xlarge` | 4 |
+| `g6e.2xlarge` | 8 |
+| `g6e.4xlarge` | 16 |
+| `g6e.8xlarge` | 32 |
+| `g6e.12xlarge` | 48 |
+| `g6e.16xlarge` | 64 |
+| `g6e.24xlarge` | 96 |
+| `g6e.48xlarge` | 192 |
 
 ## Adding new instance types
 

--- a/deploy/rosa-cpus-instance-types-config/rosa-cpus-instance-types-ConfigMap.yaml
+++ b/deploy/rosa-cpus-instance-types-config/rosa-cpus-instance-types-ConfigMap.yaml
@@ -6,3 +6,11 @@ metadata:
 data:
   i3.metal: "72"
   g6.xlarge: "4"
+  g6e.xlarge: "4"
+  g6e.2xlarge: "8"
+  g6e.4xlarge: "16"
+  g6e.8xlarge: "32"
+  g6e.12xlarge: "48"
+  g6e.16xlarge: "64"
+  g6e.24xlarge: "96"
+  g6e.48xlarge: "192"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -44599,6 +44599,14 @@ objects:
       data:
         i3.metal: '72'
         g6.xlarge: '4'
+        g6e.xlarge: '4'
+        g6e.2xlarge: '8'
+        g6e.4xlarge: '16'
+        g6e.8xlarge: '32'
+        g6e.12xlarge: '48'
+        g6e.16xlarge: '64'
+        g6e.24xlarge: '96'
+        g6e.48xlarge: '192'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -44599,6 +44599,14 @@ objects:
       data:
         i3.metal: '72'
         g6.xlarge: '4'
+        g6e.xlarge: '4'
+        g6e.2xlarge: '8'
+        g6e.4xlarge: '16'
+        g6e.8xlarge: '32'
+        g6e.12xlarge: '48'
+        g6e.16xlarge: '64'
+        g6e.24xlarge: '96'
+        g6e.48xlarge: '192'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -44599,6 +44599,14 @@ objects:
       data:
         i3.metal: '72'
         g6.xlarge: '4'
+        g6e.xlarge: '4'
+        g6e.2xlarge: '8'
+        g6e.4xlarge: '16'
+        g6e.8xlarge: '32'
+        g6e.12xlarge: '48'
+        g6e.16xlarge: '64'
+        g6e.24xlarge: '96'
+        g6e.48xlarge: '192'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
## Summary

Adds the `g6e` GPU instance family to the `rosa-cpus-instance-types-config` ConfigMap, which the hypershift-operator uses as a vCPU billing fallback when the EC2 `DescribeInstanceTypes` API returns `InvalidInstanceType`.

## Motivation

A `BillingMetricMissing` (Critical) alert fired for a healthy ROSA HCP cluster running a `g6e.xlarge` GPU nodepool in `ap-southeast-1`. AWS's `DescribeInstanceTypes` rejects `g6e.xlarge` in regions where the type is not offered, so the operator sets `hypershift_cluster_vcpus` to `-1`, firing the alert even though the nodepool is `Ready=True` and running.

This is the same class of issue addressed by [OCPBUGS-50003](https://issues.redhat.com/browse/OCPBUGS-50003) (the ConfigMap fallback mechanism, HO v0.1.75+) and previously seen with `g6` in [OCPBUGS-80923](https://issues.redhat.com/browse/OCPBUGS-80923). The existing ConfigMap covered `g6.xlarge` but not the newer `g6e` family.

## Changes

- Add `g6e.xlarge` through `g6e.48xlarge` with their vCPU counts to the ConfigMap
- Update the component README instance-types table
- Regenerate the `hack/` env templates via `make`

vCPU counts verified against the [AWS EC2 instance types documentation](https://docs.aws.amazon.com/ec2/latest/instancetypes/so.html):

| Instance Type | vCPUs |
|---|---|
| g6e.xlarge | 4 |
| g6e.2xlarge | 8 |
| g6e.4xlarge | 16 |
| g6e.8xlarge | 32 |
| g6e.12xlarge | 48 |
| g6e.16xlarge | 64 |
| g6e.24xlarge | 96 |
| g6e.48xlarge | 192 |

## Testing

- `make` regenerates the three env templates cleanly; only the ConfigMap data block changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented seven additional `g6e` EC2 instance types, covering configurations from 4 to 192 vCPUs.

* **Configuration**
  * Added CPU mappings for the new `g6e` instance types to ROSA instance configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->