### PR TITLE
ROSAENG-66134 add missing installer permission for OCP 5

### DIFF
--- a/resources/sts/5.0/sts_instance_controlplane_permission_policy.json
+++ b/resources/sts/5.0/sts_instance_controlplane_permission_policy.json
@@ -13,10 +13,11 @@
         "ec2:DescribeVpcs",
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeLoadBalancerPolicies",
         "elasticloadbalancing:DescribeListeners",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
-        "elasticloadbalancing:DescribeLoadBalancerPolicies"
+        "elasticloadbalancing:DescribeTargetGroupAttributes"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
### What type of PR is this?
Adding the missing permission in controlplane installer role for OCP 5

### What this PR does / why we need it?
Ingress operator starts to set the annotation for targetgroupattribute. CCM will need to verify the attribute which requires this permission elasticloadbalancing:DescribeTargetGroupAttributes. But this permission doesn't exist in controlplane installer role.

### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-66134](https://redhat.atlassian.net/browse/ROSAENG-66134)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated permissions for load balancer policy and target group attribute descriptions in the STS instance control-plane policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->