### PR TITLE
OCPBUGS-114936: Add poddisruptionbudgets RBAC to hypershift-addon-agent ClusterRole

### DIFF
--- a/deploy/hypershift-addon-agent-rbac/10-hypershift-addon-agent.ClusterRole.yaml
+++ b/deploy/hypershift-addon-agent-rbac/10-hypershift-addon-agent.ClusterRole.yaml
@@ -13,3 +13,16 @@ rules:
   - update
   - patch
   - create
+# Required to apply the PodDisruptionBudget the hypershift operator install creates (OCPBUGS-114936)
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30569,6 +30569,18 @@ objects:
         - update
         - patch
         - create
+      - apiGroups:
+        - policy
+        resources:
+        - poddisruptionbudgets
+        verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30569,6 +30569,18 @@ objects:
         - update
         - patch
         - create
+      - apiGroups:
+        - policy
+        resources:
+        - poddisruptionbudgets
+        verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30569,6 +30569,18 @@ objects:
         - update
         - patch
         - create
+      - apiGroups:
+        - policy
+        resources:
+        - poddisruptionbudgets
+        verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature (RBAC)_

### What this PR does / why we need it?

Adds `policy/poddisruptionbudgets` (get/list/watch/create/update/patch/delete) to the supplementary `hypershift-addon-agent` ClusterRole in `deploy/hypershift-addon-agent-rbac/`.

> [!IMPORTANT]
> **Required dependency of openshift/hypershift#9526.** Must merge (and roll out to the SRE-P/ROSA management-cluster fleet) **before** that HyperShift change reaches those clusters, or the hypershift-addon install Job breaks.

openshift/hypershift#9526 adds a `PodDisruptionBudget` to the HyperShift Operator install manifest set. On management clusters the operator is installed by the hypershift-addon **install Job**, running as `hypershift-addon-agent-sa`. On the SRE-P/ROSA fleet that SA is granted this supplementary ClusterRole (applied via the SelectorSyncSet targeting `ext-hypershift.openshift.io/cluster-type: management-cluster`). Without permission to manage `poddisruptionbudgets`, the install Job fails when it applies the PDB:

```
poddisruptionbudgets.policy "operator" is forbidden: User
"system:serviceaccount:open-cluster-management-agent-addon:hypershift-addon-agent-sa"
cannot patch resource "poddisruptionbudgets" in API group "policy" in the namespace "hypershift"
```

This grants the permission so the install Job can apply the operator PDB.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OCPBUGS-114936_

Paired PRs (same Jira):
- openshift/hypershift#9526 — adds the operator PDB
- stolostron/hypershift-addon-operator#804 — same RBAC grant in the base MCE agent ClusterRole (all MCE)

### Special notes for your reviewer:

- This modifies an **existing** ClusterRole (`hypershift-addon-agent`) already scoped to management clusters via the existing SelectorSyncSet in `config.yaml`; no new object and no change to the sync selector, so the FedRAMP exclusion pre-check does not apply here.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment ... (N/A — modifies an existing object)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon agent support for managing PodDisruptionBudgets, including creating, updating, monitoring, and deleting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->