### PR TITLE
ROSAENG-66261: NetworkPolicy for hypershift-observability kube-state-metrics (MC + SC)

### DIFF
--- a/deploy/hypershift-kube-state-metrics/080-networkpolicy.yaml
+++ b/deploy/hypershift-kube-state-metrics/080-networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # RHOBS / Observability Operator scrape (ServiceMonitor monitoring.rhobs/v1).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8081
+  # Kubelet liveness/readiness probes (host-network).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: host-network
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8081
+  egress:
+  # CoreDNS in openshift-dns (port 5353).
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API (host-networked; KSM custom-resource-state).
+  - ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/deploy/hypershift-sc-kube-state-metrics/080-networkpolicy.yaml
+++ b/deploy/hypershift-sc-kube-state-metrics/080-networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # RHOBS / Observability Operator scrape (ServiceMonitor monitoring.rhobs/v1).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8081
+  # Kubelet liveness/readiness probes (host-network).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: host-network
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8081
+  egress:
+  # CoreDNS in openshift-dns (port 5353).
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API (host-networked; KSM custom-resource-state).
+  - ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30981,6 +30981,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -32177,6 +32225,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30981,6 +30981,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -32177,6 +32225,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30981,6 +30981,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -32177,6 +32225,54 @@ objects:
         - port: http-metrics
           interval: 30s
           path: /metrics
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        policyTypes:
+        - Ingress
+        - Egress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: monitoring
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: host-network
+          ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8081
+        egress:
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-dns
+          ports:
+          - protocol: UDP
+            port: 5353
+          - protocol: TCP
+            port: 5353
+        - ports:
+          - protocol: TCP
+            port: 6443
+          - protocol: TCP
+            port: 443
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
## Summary

- Add the same NetworkPolicy to **both** KSM SelectorSyncSets in `hypershift-observability` (MC + SC). Do **not** add SC-only.
- Follow-up from CodeRabbit on [#2866](https://github.com/openshift/managed-cluster-config/pull/2866); tracked instead of blocking that PR ([ROSAENG-66261](https://redhat.atlassian.net/browse/ROSAENG-66261)).
- Ingress: scrape from `network.openshift.io/policy-group: monitoring` (RHOBS / OBO) and kubelet probes from `host-network`, TCP 8080/8081.
- Egress: `openshift-dns` 5353 and TCP 6443/443 for the API (`--custom-resource-state-only`).
- Hive templates regenerated (`hack/00-osd-managed-cluster-config-{integration,stage,production}.yaml.tmpl`).

### What type of PR is this?
feature

### What this PR does / why we need it?
Restrict kube-state-metrics in `hypershift-observability` on management-cluster and service-cluster without diverging the two stacks.

### Which Jira/Github issue(s) this PR fixes?
[ROSAENG-66261](https://redhat.atlassian.net/browse/ROSAENG-66261)

## Test plan

- [ ] SSS still selects MC vs SC as before (not FedRAMP)
- [ ] After pin: KSM pod Ready on a stage MC and stage SC
- [ ] `certmanager_challenge_cr_info` still scraped (queue alerts not broken)
- [ ] NetworkPolicy present in `hypershift-observability` on both


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network access controls for kube-state-metrics.
  * Enabled metrics scraping and health probes.
  * Allowed required communication with DNS and the Kubernetes API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->