### PR TITLE
APPSRE-12877: Enable OADP configuration for Hive clusters

### DIFF
--- a/deploy/oadp-configuration/hive-specific/05-oadp-schedule-admins-cluster.ClusterRole.yaml
+++ b/deploy/oadp-configuration/hive-specific/05-oadp-schedule-admins-cluster.ClusterRole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
+  name: oadp-schedule-admins-cluster
+rules:
+- apiGroups:
+  - velero.io
+  attributeRestrictions: null
+  resources:
+  - schedules
+  - backups
+  - restores
+  verbs:
+  - "*"
+- apiGroups:
+  - oadp.openshift.io
+  attributeRestrictions: null
+  resources:
+  - dataprotectionapplications
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/oadp-configuration/hive-specific/111-oadp.Schedules.yaml
+++ b/deploy/oadp-configuration/hive-specific/111-oadp.Schedules.yaml
@@ -1,0 +1,29 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: 5min-object-backup
+  namespace: openshift-adp
+spec:
+  schedule: '*/5 * * * *'
+  template:
+    includedNamespaces:
+    - '*'
+    excludedResources:
+    - imagetags.image.openshift.io
+    - images.image.openshift.io
+    - oauthaccesstokens.oauth.openshift.io
+    - oauthauthorizetokens.oauth.openshift.io
+    - templateinstances.template.openshift.io
+    - clusterserviceversions.operators.coreos.com
+    - packagemanifests.packages.operators.coreos.com
+    - operatorgroups.operators.coreos.com
+    - subscriptions.operators.coreos.com
+    - servicebrokers.servicecatalog.k8s.io
+    - servicebindings.servicecatalog.k8s.io
+    - serviceclasses.servicecatalog.k8s.io
+    - serviceinstances.servicecatalog.k8s.io
+    - serviceplans.servicecatalog.k8s.io
+    - events.events.k8s.io
+    - events
+    snapshotVolumes: false
+    ttl: 0h25m0s

--- a/deploy/oadp-configuration/hive-specific/config.yaml
+++ b/deploy/oadp-configuration/hive-specific/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchLabels:
+    ext-managed.openshift.io/hive-shard: "true"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32915,6 +32915,80 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: oadp-configuration-hive-specific
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: oadp-schedule-admins-cluster
+      rules:
+      - apiGroups:
+        - velero.io
+        attributeRestrictions: null
+        resources:
+        - schedules
+        - backups
+        - restores
+        verbs:
+        - '*'
+      - apiGroups:
+        - oadp.openshift.io
+        attributeRestrictions: null
+        resources:
+        - dataprotectionapplications
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: velero.io/v1
+      kind: Schedule
+      metadata:
+        name: 5min-object-backup
+        namespace: openshift-adp
+      spec:
+        schedule: '*/5 * * * *'
+        template:
+          includedNamespaces:
+          - '*'
+          excludedResources:
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
+          - events
+          snapshotVolumes: false
+          ttl: 0h25m0s
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32915,6 +32915,80 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: oadp-configuration-hive-specific
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: oadp-schedule-admins-cluster
+      rules:
+      - apiGroups:
+        - velero.io
+        attributeRestrictions: null
+        resources:
+        - schedules
+        - backups
+        - restores
+        verbs:
+        - '*'
+      - apiGroups:
+        - oadp.openshift.io
+        attributeRestrictions: null
+        resources:
+        - dataprotectionapplications
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: velero.io/v1
+      kind: Schedule
+      metadata:
+        name: 5min-object-backup
+        namespace: openshift-adp
+      spec:
+        schedule: '*/5 * * * *'
+        template:
+          includedNamespaces:
+          - '*'
+          excludedResources:
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
+          - events
+          snapshotVolumes: false
+          ttl: 0h25m0s
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32915,6 +32915,80 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: oadp-configuration-hive-specific
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: oadp-schedule-admins-cluster
+      rules:
+      - apiGroups:
+        - velero.io
+        attributeRestrictions: null
+        resources:
+        - schedules
+        - backups
+        - restores
+        verbs:
+        - '*'
+      - apiGroups:
+        - oadp.openshift.io
+        attributeRestrictions: null
+        resources:
+        - dataprotectionapplications
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: velero.io/v1
+      kind: Schedule
+      metadata:
+        name: 5min-object-backup
+        namespace: openshift-adp
+      spec:
+        schedule: '*/5 * * * *'
+        template:
+          includedNamespaces:
+          - '*'
+          excludedResources:
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
+          - events
+          snapshotVolumes: false
+          ttl: 0h25m0s
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Enables OADP for Hive-managed clusters as the first (additive) step of the MVO→OADP migration.

Adds a new oadp-configuration/hive-specific SelectorSyncSet that deploys, to Hive-shard clusters (excluding FedRAMP):
- A 5min-object-backup Velero Schedule in the openshift-adp namespace (all namespaces, platform resources excluded, no volume snapshots, 25m TTL) — mirroring the existing MVO hive schedule.
- An oadp-schedule-admins-cluster ClusterRole aggregated to dedicated-admins, granting management of Velero schedules/backups/restores and read-only access to OADP dataprotectionapplications.

### Which Jira/Github issue(s) this PR fixes?
[APPSRE-12877](https://redhat.atlassian.net/browse/APPSRE-12877)

_Fixes #_

### Special notes for your reviewer:
Special notes for your reviewer:

- Additive only / no removals — no MVO resources are deleted in this PR; generated templates show insertions only (0 deletions).
- RBAC least-privilege — the schedule-admins ClusterRole uses explicit lifecycle verbs (create/delete/get/list/patch/update/watch) rather than a wildcard, matching the osd-custom-domains dedicated-admins precedent.
- Prerequisite — the schedule targets the openshift-adp namespace, so it relies on the base OADP operator being present on Hive shards (delivered via the main oadp-configuration, selector product In [osd,rosa]). Please confirm ordering if base OADP is not yet rolled out to Hive shards.


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Velero backups every five minutes for eligible clusters.
  - Backups include all namespaces, exclude selected platform resources, omit volume snapshots, and expire after 25 minutes.
  - Added dedicated administrator access to manage Velero schedules, backups, and restores, with read-only access to OADP application configurations.
  - Enabled deployment of this OADP configuration to matching Hive-managed clusters, excluding FedRAMP clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->